### PR TITLE
Retrobat

### DIFF
--- a/emulatorLauncher/Generators/LibRetro.Generator.cs
+++ b/emulatorLauncher/Generators/LibRetro.Generator.cs
@@ -590,7 +590,7 @@ namespace emulatorLauncher.libRetro
             // RetroArch 1.7.8 requires the shaders to be passed as command line argument      
             if (AppConfig.isOptSet("shaders") && SystemConfig.isOptSet("shader") && SystemConfig["shader"] != "None")
             {
-                string shaderFilename = SystemConfig["shader"] + ".glslp";
+                string shaderFilename = SystemConfig["shader"] + ".slangp";
                 string videoShader = Path.Combine(AppConfig.GetFullPath("shaders"), shaderFilename).Replace("/", "\\");
                 if (File.Exists(videoShader))
                 {
@@ -603,7 +603,7 @@ namespace emulatorLauncher.libRetro
 
             return new ProcessStartInfo()
             {
-                FileName = Path.Combine(RetroarchPath, "retroarch.exe"),
+                FileName = Path.Combine(RetroarchPath, emulator == "angle" ? "retroarch_angle.exe" : "retroarch.exe"),
                 WorkingDirectory = RetroarchPath,                
                 Arguments =
                     string.IsNullOrEmpty(rom) ?

--- a/emulatorLauncher/Program.cs
+++ b/emulatorLauncher/Program.cs
@@ -31,7 +31,7 @@ namespace emulatorLauncher
     {
         static Dictionary<string, Func<Generator>> generators = new Dictionary<string, Func<Generator>>
         {
-            { "libretro", () => new LibRetroGenerator() },
+            { "libretro", () => new LibRetroGenerator() }, { "angle", () => new LibRetroGenerator() },      
             { "model2", () => new Model2Generator() },
             { "model3", () => new Model3Generator() }, { "supermodel", () => new Model3Generator() },
             { "openbor", () => new OpenBorGenerator() },


### PR DESCRIPTION
- add angle support for retroarch

- replace *.glslp extension for shaders with *.slangp extension (compatible with glcore, d3d and vulkan video drivers instead of gl drivers).