### PR TITLE
FIX PCSX2 generator for user hacks features and fix rpsc3 generator (features inverted)

### DIFF
--- a/emulatorLauncher/Generators/Pcsx2.Generator.cs
+++ b/emulatorLauncher/Generators/Pcsx2.Generator.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Windows.Forms;
 using System.Drawing;
 using System.Management;
+using emulatorLauncher.Tools;
 
 namespace emulatorLauncher
 {
@@ -327,9 +328,36 @@ namespace emulatorLauncher
                         ini.WriteValue("Settings", "TVShader", "0");
 
                     if (SystemConfig.isOptSet("Offset") && !string.IsNullOrEmpty(SystemConfig["Offset"]))
+                    {
                         ini.WriteValue("Settings", "UserHacks_WildHack", SystemConfig["Offset"]);
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
                     else if (Features.IsSupported("Offset"))
                         ini.WriteValue("Settings", "UserHacks_WildHack", "0");
+
+                    if (SystemConfig.isOptSet("UserHacks_HalfPixelOffset") && !string.IsNullOrEmpty(SystemConfig["UserHacks_HalfPixelOffset"]))
+                    {
+                        ini.WriteValue("Settings", "UserHacks_HalfPixelOffset", SystemConfig["UserHacks_HalfPixelOffset"]);
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
+                    else if (Features.IsSupported("Offset"))
+                        ini.WriteValue("Settings", "UserHacks_HalfPixelOffset", "0");
+
+                    if (SystemConfig.isOptSet("UserHacks_Half_Bottom_Override") && !string.IsNullOrEmpty(SystemConfig["UserHacks_Half_Bottom_Override"]))
+                    {
+                        ini.WriteValue("Settings", "UserHacks_Half_Bottom_Override", SystemConfig["UserHacks_Half_Bottom_Override"]);
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
+                    else if (Features.IsSupported("Offset"))
+                        ini.WriteValue("Settings", "UserHacks_Half_Bottom_Override", "-1");
+
+                    if (SystemConfig.isOptSet("UserHacks_round_sprite_offset") && !string.IsNullOrEmpty(SystemConfig["UserHacks_round_sprite_offset"]))
+                    {
+                        ini.WriteValue("Settings", "UserHacks_round_sprite_offset", SystemConfig["UserHacks_round_sprite_offset"]);
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
+                    else if (Features.IsSupported("Offset"))
+                        ini.WriteValue("Settings", "UserHacks_round_sprite_offset", "0");
 
                     if (SystemConfig.isOptSet("bilinear_filtering") && !string.IsNullOrEmpty(SystemConfig["bilinear_filtering"]))
                         ini.WriteValue("Settings", "linear_present", SystemConfig["bilinear_filtering"]);
@@ -357,14 +385,82 @@ namespace emulatorLauncher
                         ini.WriteValue("Settings", "MaxAnisotropy", "0");
 
                     if (SystemConfig.isOptSet("align_sprite") && !string.IsNullOrEmpty(SystemConfig["align_sprite"]))
+                    {
                         ini.WriteValue("Settings", "UserHacks_align_sprite_X", SystemConfig["align_sprite"]);
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
                     else if (Features.IsSupported("align_sprite"))
                         ini.WriteValue("Settings", "UserHacks_align_sprite_X", "0");
 
-                    if (SystemConfig.isOptSet("skipdraw") && !string.IsNullOrEmpty(SystemConfig["skipdraw"]))
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw", SystemConfig["skipdraw"]);
+                    if (SystemConfig.isOptSet("UserHacks_merge_pp_sprite") && !string.IsNullOrEmpty(SystemConfig["UserHacks_merge_pp_sprite"]))
+                    {
+                        ini.WriteValue("Settings", "UserHacks_merge_pp_sprite", SystemConfig["UserHacks_merge_pp_sprite"]);
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
+                    else if (Features.IsSupported("align_sprite"))
+                        ini.WriteValue("Settings", "UserHacks_merge_pp_sprite", "0");
+
+                    if (SystemConfig.isOptSet("UserHacks_Disable_Safe_Features") && !string.IsNullOrEmpty(SystemConfig["UserHacks_Disable_Safe_Features"]))
+                    {
+                        ini.WriteValue("Settings", "UserHacks_Disable_Safe_Features", SystemConfig["UserHacks_Disable_Safe_Features"]);
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
+                    else if (Features.IsSupported("UserHacks_Disable_Safe_Features"))
+                        ini.WriteValue("Settings", "UserHacks_Disable_Safe_Features", "0");
+
+                    if (SystemConfig.isOptSet("TextureOffsets") && (SystemConfig["TextureOffsets"] == "1"))
+                    {
+                        ini.WriteValue("Settings", "UserHacks_TCOffsetX", "500");
+                        ini.WriteValue("Settings", "UserHacks_TCOffsetY", "500");
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
+                    else if (SystemConfig.isOptSet("TextureOffsets") && (SystemConfig["TextureOffsets"] == "2"))
+                    {
+                        ini.WriteValue("Settings", "UserHacks_TCOffsetX", "0");
+                        ini.WriteValue("Settings", "UserHacks_TCOffsetY", "1000");
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
+                    else if (Features.IsSupported("TextureOffsets"))
+                    {
+                        ini.WriteValue("Settings", "UserHacks_TCOffsetX", "0");
+                        ini.WriteValue("Settings", "UserHacks_TCOffsetY", "0");
+                    }
+
+                    if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "1"))
+                    {
+                        ini.WriteValue("Settings", "UserHacks_SkipDraw_Start", "1");
+                        ini.WriteValue("Settings", "UserHacks_SkipDraw_End", "1");
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
+                    else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "2"))
+                    {
+                        ini.WriteValue("Settings", "UserHacks_SkipDraw_Start", "1");
+                        ini.WriteValue("Settings", "UserHacks_SkipDraw_End", "2");
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
+                    else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "3"))
+                    {
+                        ini.WriteValue("Settings", "UserHacks_SkipDraw_Start", "1");
+                        ini.WriteValue("Settings", "UserHacks_SkipDraw_End", "3");
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
+                    else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "4"))
+                    {
+                        ini.WriteValue("Settings", "UserHacks_SkipDraw_Start", "1");
+                        ini.WriteValue("Settings", "UserHacks_SkipDraw_End", "4");
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
+                    else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "5"))
+                    {
+                        ini.WriteValue("Settings", "UserHacks_SkipDraw_Start", "1");
+                        ini.WriteValue("Settings", "UserHacks_SkipDraw_End", "5");
+                        ini.WriteValue("Settings", "UserHacks", "1");
+                    }
                     else if (Features.IsSupported("skipdraw"))
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw", "0");
+                    {
+                        ini.WriteValue("Settings", "UserHacks_SkipDraw_Start", "0");
+                        ini.WriteValue("Settings", "UserHacks_SkipDraw_End", "0");
+                    }
 
                     //Custom textures
                     if (SystemConfig.isOptSet("hires_textures") && SystemConfig.getOptBoolean("hires_textures"))

--- a/emulatorLauncher/Generators/Rpcs3.Generator.cs
+++ b/emulatorLauncher/Generators/Rpcs3.Generator.cs
@@ -111,50 +111,50 @@ namespace emulatorLauncher
 
             // Handle Core part of yml file
             var core = yml.GetOrCreateContainer("Core");
-            BindFeature(core, "ppudecoder", "PPU Decoder", "Recompiler (LLVM)");
-            BindFeature(core, "lvmprecomp", "PPU LLVM Precompilation", "true");
-            BindFeature(core, "spudecoder", "SPU Decoder", "Recompiler (LLVM)");
-            BindFeature(core, "lowerspuprio", "Lower SPU thread priority", "false");
-            BindFeature(core, "sputhreads", "Preferred SPU Threads", "0");
-            BindFeature(core, "spuloopdetect", "SPU loop detection", "false");
-            BindFeature(core, "spublocksize", "SPU Block Size", "Safe");
-            BindFeature(core, "accuratersx", "Accurate RSX reservation access", "false");
-            BindFeature(core, "accuratexfloat", "Accurate xfloat", "false");
-            BindFeature(core, "vectornan", "PPU LLVM Accurate Vector NaN values", "false");
-            BindFeature(core, "fullavx", "Full Width AVX-512", "false");
+            BindFeature(core, "PPU Decoder", "ppudecoder", "Recompiler (LLVM)");
+            BindFeature(core, "PPU LLVM Precompilation", "lvmprecomp", "true");
+            BindFeature(core, "SPU Decoder", "spudecoder", "Recompiler (LLVM)");
+            BindFeature(core, "Lower SPU thread priority", "lowerspuprio", "false");
+            BindFeature(core, "Preferred SPU Threads", "sputhreads", "0");
+            BindFeature(core, "SPU loop detection", "spuloopdetect", "false");
+            BindFeature(core, "SPU Block Size", "spublocksize", "Safe");
+            BindFeature(core, "Accurate RSX reservation access", "accuratersx", "false");
+            BindFeature(core, "Accurate xfloat", "accuratexfloat", "false");
+            BindFeature(core, "PPU LLVM Accurate Vector NaN values", "vectornan", "false");
+            BindFeature(core, "Full Width AVX-512", "fullavx", "false");
             
             // Handle Video part of yml file
             var video = yml.GetOrCreateContainer("Video");
-            BindFeature(video, "gfxbackend", "Renderer", "Vulkan");
-            BindFeature(video, "rpcs3_internal_resolution", "Resolution", "1280x720");
-            BindFeature(video, "ratio", "Aspect ratio", "16:9");
-            BindFeature(video, "framelimit", "Frame limit", "Auto");
-            BindFeature(video, "msaa", "MSAA", "Auto");
-            BindFeature(video, "shadermode", "Shader Mode", "Async Shader Recompiler");
-            BindFeature(video, "writecolorbuffers", "Write Color Buffers", "false");
-            BindFeature(video, "writedepthbuffers", "Write Depth Buffer", "false");
-            BindFeature(video, "readcolorbuffers", "Read Color Buffers", "false");
-            BindFeature(video, "readdepthbuffers", "Read Depth Buffer", "false");
-            BindFeature(video, "vsync", "VSync", "false");
-            BindFeature(video, "stretchtodisplay", "Stretch To Display Area", "false");
-            BindFeature(video, "strict_rendering", "Strict Rendering Mode", "false");
-            BindFeature(video, "disablevertex", "Disable Vertex Cache", "false");
-            BindFeature(video, "multithreadedrsx", "Multithreaded RSX", "false");
-            BindFeature(video, "enable3d", "Enable 3D", "false");
-            BindFeature(video, "anisotropicfilter", "Anisotropic Filter Override", "0");
+            BindFeature(video, "Renderer", "gfxbackend", "Vulkan");
+            BindFeature(video, "Resolution", "rpcs3_internal_resolution", "1280x720");
+            BindFeature(video, "Aspect ratio", "ratio", "16:9");
+            BindFeature(video, "Frame limit", "framelimit", "Auto");
+            BindFeature(video, "MSAA", "msaa", "Auto");
+            BindFeature(video, "Shader Mode", "shadermode", "Async Shader Recompiler");
+            BindFeature(video, "Write Color Buffers", "writecolorbuffers", "false");
+            BindFeature(video, "Write Depth Buffer", "writedepthbuffers", "false");
+            BindFeature(video, "Read Color Buffers", "readcolorbuffers", "false");
+            BindFeature(video, "Read Depth Buffer", "readdepthbuffers", "false");
+            BindFeature(video, "VSync", "vsync", "false");
+            BindFeature(video, "Stretch To Display Area", "stretchtodisplay", "false");
+            BindFeature(video, "Strict Rendering Mode", "strict_rendering", "false");
+            BindFeature(video, "Disable Vertex Cache", "disablevertex", "false");
+            BindFeature(video, "Multithreaded RSX", "multithreadedrsx", "false");
+            BindFeature(video, "Enable 3D", "enable3d", "false");
+            BindFeature(video, "Anisotropic Filter Override", "anisotropicfilter", "0");
             
             // Handle Vulkan part of yml file
             var vulkan = video.GetOrCreateContainer("Vulkan");
-            BindFeature(vulkan, "asynctexturestream", "Asynchronous Texture Streaming 2", "false");
+            BindFeature(vulkan, "Asynchronous Texture Streaming 2", "asynctexturestream", "false");
             
             // Handle Audio part of yml file
             var audio = yml.GetOrCreateContainer("Audio");
-            BindFeature(audio, "audiobackend", "Renderer", "XAudio2");
-            BindFeature(audio, "audiochannels", "Audio Format", "Downmix to Stereo");
+            BindFeature(audio, "Renderer", "audiobackend", "XAudio2");
+            BindFeature(audio, "Audio Format", "audiochannels", "Downmix to Stereo");
             
             // Handle Miscellaneous part of yml file
             var misc = yml.GetOrCreateContainer("Miscellaneous");
-            BindFeature(misc, "startfullscreen", "Start games in fullscreen mode", "true");
+            BindFeature(misc, "Start games in fullscreen mode", "startfullscreen", "true");
 
             // Save to yml file
             yml.Save();


### PR DESCRIPTION
- Fix (wild cards hack, half pixel offset, half bottom override, round sprite offset, merge pp sprite, disable safe features, texture offsets, skip draw,)
- Automatically activate user hacks if one of the user hacks feature is selected (else the feature will not work)