### PR TITLE
Fix real wiimotes ini generator

### DIFF
--- a/emulatorLauncher/Generators/Dolphin.Controllers.cs
+++ b/emulatorLauncher/Generators/Dolphin.Controllers.cs
@@ -307,10 +307,10 @@ namespace emulatorLauncher
 
             using (IniFile ini = new IniFile(iniFile, IniOptions.UseSpaces))
             {
-                for (int i = 0; i < 5; i++)
+                for (int i = 1; i < 5; i++)
                 {
-                    ini.ClearSection("[" + anyDefKey + i.ToString() + "]");
-                    ini.WriteValue("[" + anyDefKey + i.ToString() + "]", "Source", "2");
+                    ini.ClearSection(anyDefKey + i.ToString());
+                    ini.WriteValue(anyDefKey + i.ToString(), "Source", "2");
                 }
 
                 ini.Save();


### PR DESCRIPTION
When setting "real wiimotes", the wiimote sections in the WiimotNew.ini files get wrongly created:
- Section gets created as [ [ WiimoteX] ] instead of [ WiimoteX ]
- Starts with Wiimote0 instead of Wiimote1