### PR TITLE
Update Yuzu.Controllers.cs

### DIFF
--- a/emulatorLauncher/Generators/Yuzu.Controllers.cs
+++ b/emulatorLauncher/Generators/Yuzu.Controllers.cs
@@ -48,7 +48,7 @@ namespace emulatorLauncher
                 if (controller.SdlWrappedTechID == SdlWrappedTechId.RawInput && controller.XInput != null)
                 {
                     var guid = yuzuGuid.FromSdlGuidString();
-                    yuzuGuid = guid.ToXInputGuid(controller.XInput.DeviceIndex + 1).ToSdlGuidString();
+                    yuzuGuid = guid.ToXInputGuid(01).ToSdlGuidString();
                 }
             }
 


### PR DESCRIPTION
Fix for yuzu controllers, all xinput controllers end with 7801, the 2 last digits are not a player index