### PR TITLE
Update Dolphin.Generator.cs

### DIFF
--- a/emulatorLauncher/Generators/Dolphin.Generator.cs
+++ b/emulatorLauncher/Generators/Dolphin.Generator.cs
@@ -107,6 +107,9 @@ namespace emulatorLauncher
 
             DolphinControllers.WriteControllersConfig(path, system, rom);
 
+            if (Path.GetExtension(rom).ToLowerInvariant() == ".m3u")
+                rom = rom.Replace("\\", "/");
+
             return new ProcessStartInfo()
             {
                 FileName = exe,


### PR DESCRIPTION
Fix m3u loading with relative paths for dolphin standalone.
Using / instead of \ in the command line (only for m3u) work to run m3u's with relative paths.

