### PR TITLE
DEMUL fix for running dreamcast roms + added features

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -3117,7 +3117,50 @@
   </emulator>
   <!-- DEMUL -->
   <emulator name="demul">
+    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="VSync">
+      <choice name="NO" value="0"/>
+      <choice name="YES" value="1"/>
+    </feature>
+    <feature name="GAME ASPECT RATIO" group="GENERAL SETTINGS" value="ratio">
+      <choice name="16/9" value="2"/>
+      <choice name="4/3" value="1"/>
+      <choice name="STRETCHED" value="0"/>
+    </feature>
     <sharedFeature group="ADVANCED SETTINGS" value="videomode"/>
+    <feature submenu="VIDEO" name="VIDEO MODE" group="ADVANCED SETTINGS" value="videomode">
+      <choice name="AUTO" value="1024"/>
+      <choice name="VGA" value="0"/>
+      <choice name="TV (RGB)" value="512"/>
+      <choice name="TV (VBS/S, RF)" value="768"/>
+      <choice name="RESERVED" value="256"/>
+    </feature>
+    <feature submenu="USER INTERFACE" name="START GAME IN FULLSCREEN" group="ADVANCED SETTINGS" value="startfullscreen" description="Start game in fullscreen, default no.">
+      <choice name="YES" value="1"/>
+      <choice name="NO" value="0"/>
+    </feature>
+    <feature submenu="EMULATION" name="CPU MODE" group="ADVANCED SETTINGS" value="cpumode">
+      <choice name="DYNAREC" value="1"/>
+      <choice name="INTERPRETER" value="0"/>
+    </feature>
+    <system name="dreamcast">
+      <feature submenu="EMULATION" name="TIME HACK" group="ADVANCED SETTINGS" value="timehack">
+        <choice name="YES" value="true"/>
+        <choice name="NO" value="false"/>
+      </feature>
+      <feature submenu="EMULATION" name="DREAMCAST REGION" group="ADVANCED SETTINGS" value="dc_region">
+        <choice name="AUTO REGION" value="1"/>
+        <choice name="JAPAN" value="48"/>
+        <choice name="AMERICA" value="49"/>
+        <choice name="EUROPE" value="50"/>
+      </feature>
+      <feature submenu="EMULATION" name="BROADCAST" group="ADVANCED SETTINGS" value="dc_broadcast">
+        <choice name="AUTO BROADCAST" value="1"/>
+        <choice name="NTSC" value="48"/>
+        <choice name="PAL" value="49"/>
+        <choice name="PAL-M" value="50"/>
+        <choice name="PAL-N" value="51"/>
+      </feature>
+    </system>
   </emulator>
   <emulator name="demul-old">
     <sharedFeature group="ADVANCED SETTINGS" value="videomode"/>


### PR DESCRIPTION
For dreamcast, DEMUL was sending wrong run command: 
was run=dreamcast -rom""
Should have been run=dc -image""

Addition of extra features for demul emulator also