### PR TITLE
PCSX2 - skipdraw feature

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -2939,6 +2939,7 @@
   </emulator>
   <!-- BIGPEMU -->
   <emulator name="bigpemu">
+    <sharedFeature group="GENERAL SETTINGS" value="shaderset"/>
     <sharedFeature group="GENERAL SETTINGS" value="bezel"/>
     <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="vsync">
       <choice name="YES" value="1"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -3833,7 +3833,7 @@
         <choice name="3" value="3"/>
         <choice name="4" value="4"/>
         <choice name="5" value="5"/>
-		<choice name="6/6 (BULLY)" value="bully"/>
+        <choice name="6/6 (BULLY)" value="bully"/>
       </feature>
       <feature submenu="MANUAL HACKS" name="DISABLE SAFE FEATURES" group="ADVANCED SETTINGS" value="UserHacks_Disable_Safe_Features" description="Disabling safe features can help various games such as Xenosaga, Kingdom Hearts...">
         <choice name="YES" value="true"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -3833,6 +3833,7 @@
         <choice name="3" value="3"/>
         <choice name="4" value="4"/>
         <choice name="5" value="5"/>
+		<choice name="6/6 (BULLY)" value="bully"/>
       </feature>
       <feature submenu="MANUAL HACKS" name="DISABLE SAFE FEATURES" group="ADVANCED SETTINGS" value="UserHacks_Disable_Safe_Features" description="Disabling safe features can help various games such as Xenosaga, Kingdom Hearts...">
         <choice name="YES" value="true"/>

--- a/emulatorLauncher/Generators/BigPEmu.Generator.cs
+++ b/emulatorLauncher/Generators/BigPEmu.Generator.cs
@@ -13,26 +13,6 @@ namespace emulatorLauncher
 {
     class BigPEmuGenerator : Generator
     {
-        public BigPEmuGenerator()
-        {
-            DependsOnDesktopResolution = true;
-        }
-
-        public override int RunAndWait(ProcessStartInfo path)
-        {
-            FakeBezelFrm bezel = null;
-
-            if (_bezelFileInfo != null)
-                bezel = _bezelFileInfo.ShowFakeBezel(_resolution);
-
-            int ret = base.RunAndWait(path);
-
-            if (bezel != null)
-                bezel.Dispose();
-
-            return ret;
-        }
-
         private BezelFiles _bezelFileInfo;
         private ScreenResolution _resolution;
 
@@ -45,9 +25,9 @@ namespace emulatorLauncher
                 return null;
 
             //Applying bezels
-            if (!SystemConfig.isOptSet("displaymode") || SystemConfig["displaymode"] == "0")
+            if (!ReshadeManager.Setup(ReshadeBezelType.opengl, ReshadePlatform.x64, system, rom, path, resolution))
                 _bezelFileInfo = BezelFiles.GetBezelFiles(system, rom, resolution);
-            
+
             _resolution = resolution;
 
             List<string> commandArray = new List<string>();
@@ -68,6 +48,21 @@ namespace emulatorLauncher
                 WorkingDirectory = path,
                 Arguments = args,
             };
+        }
+
+        public override int RunAndWait(ProcessStartInfo path)
+        {
+            FakeBezelFrm bezel = null;
+
+            if (_bezelFileInfo != null)
+                bezel = _bezelFileInfo.ShowFakeBezel(_resolution);
+
+            int ret = base.RunAndWait(path);
+
+            if (bezel != null)
+                bezel.Dispose();
+
+            return ret;
         }
 
         //Configuration file in json format "BigPEmuConfig.bigpcfg"

--- a/emulatorLauncher/Generators/Pcsx2.Generator.cs
+++ b/emulatorLauncher/Generators/Pcsx2.Generator.cs
@@ -483,42 +483,84 @@ namespace emulatorLauncher
                         ini.WriteValue("Settings", "UserHacks_TCOffsetY", "0");
                     }
 
-                    //Skipdraw Range (both 1.6 & 1.7)
-                    if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "1"))
+                    //Skipdraw Range (ini has different values between 1.6 - gsdx.ini & 1.7 - gs.ini)
+                    if (!_isPcsx17)
                     {
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw_Start", "1");
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw_End", "1");
-                        ini.WriteValue("Settings", "UserHacks", "1");
+                        if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "1"))
+                        {
+                            ini.WriteValue("Settings", "UserHacks_SkipDraw_Offset", "1");
+                            ini.WriteValue("Settings", "UserHacks_SkipDraw", "1");
+                            ini.WriteValue("Settings", "UserHacks", "1");
+                        }
+                        else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "2"))
+                        {
+                            ini.WriteValue("Settings", "UserHacks_SkipDraw_Offset", "1");
+                            ini.WriteValue("Settings", "UserHacks_SkipDraw", "2");
+                            ini.WriteValue("Settings", "UserHacks", "1");
+                        }
+                        else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "3"))
+                        {
+                            ini.WriteValue("Settings", "UserHacks_SkipDraw_Offset", "1");
+                            ini.WriteValue("Settings", "UserHacks_SkipDraw", "3");
+                            ini.WriteValue("Settings", "UserHacks", "1");
+                        }
+                        else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "4"))
+                        {
+                            ini.WriteValue("Settings", "UserHacks_SkipDraw_Offset", "1");
+                            ini.WriteValue("Settings", "UserHacks_SkipDraw", "4");
+                            ini.WriteValue("Settings", "UserHacks", "1");
+                        }
+                        else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "5"))
+                        {
+                            ini.WriteValue("Settings", "UserHacks_SkipDraw_Offset", "1");
+                            ini.WriteValue("Settings", "UserHacks_SkipDraw", "5");
+                            ini.WriteValue("Settings", "UserHacks", "1");
+                        }
+                        else if (Features.IsSupported("skipdraw"))
+                        {
+                            ini.WriteValue("Settings", "UserHacks_SkipDraw_Offset", "0");
+                            ini.WriteValue("Settings", "UserHacks_SkipDraw", "0");
+                        }
                     }
-                    else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "2"))
+                    else
                     {
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw_Start", "1");
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw_End", "2");
-                        ini.WriteValue("Settings", "UserHacks", "1");
+                        if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "1"))
+                        {
+                            ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_Start", "1");
+                            ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_End", "1");
+                            ini.WriteValue("EmuCore/GS", "UserHacks", "true");
+                        }
+                        else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "2"))
+                        {
+                            ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_Start", "1");
+                            ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_End", "2");
+                            ini.WriteValue("EmuCore/GS", "UserHacks", "true");
+                        }
+                        else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "3"))
+                        {
+                            ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_Start", "1");
+                            ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_End", "3");
+                            ini.WriteValue("EmuCore/GS", "UserHacks", "true");
+                        }
+                        else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "4"))
+                        {
+                            ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_Start", "1");
+                            ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_End", "4");
+                            ini.WriteValue("EmuCore/GS", "UserHacks", "true");
+                        }
+                        else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "5"))
+                        {
+                            ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_Start", "1");
+                            ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_End", "5");
+                            ini.WriteValue("EmuCore/GS", "UserHacks", "true");
+                        }
+                        else if (Features.IsSupported("skipdraw"))
+                        {
+                            ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_Start", "0");
+                            ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_End", "0");
+                        }
                     }
-                    else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "3"))
-                    {
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw_Start", "1");
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw_End", "3");
-                        ini.WriteValue("Settings", "UserHacks", "1");
-                    }
-                    else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "4"))
-                    {
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw_Start", "1");
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw_End", "4");
-                        ini.WriteValue("Settings", "UserHacks", "1");
-                    }
-                    else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "5"))
-                    {
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw_Start", "1");
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw_End", "5");
-                        ini.WriteValue("Settings", "UserHacks", "1");
-                    }
-                    else if (Features.IsSupported("skipdraw"))
-                    {
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw_Start", "0");
-                        ini.WriteValue("Settings", "UserHacks_SkipDraw_End", "0");
-                    }
+
                     //CRC Hack Level
                     if (SystemConfig.isOptSet("crc_hack_level") && !string.IsNullOrEmpty(SystemConfig["crc_hack_level"]))
                         ini.WriteValue("Settings", "crc_hack_level", SystemConfig["crc_hack_level"]);

--- a/emulatorLauncher/Generators/Pcsx2.Generator.cs
+++ b/emulatorLauncher/Generators/Pcsx2.Generator.cs
@@ -865,6 +865,12 @@ namespace emulatorLauncher
                     ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_End", "5");
                     ini.WriteValue("EmuCore/GS", "UserHacks", "true");
                 }
+                else if (SystemConfig.isOptSet("skipdraw") && (SystemConfig["skipdraw"] == "bully"))
+                {
+                    ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_Start", "6");
+                    ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_End", "6");
+                    ini.WriteValue("EmuCore/GS", "UserHacks", "true");
+                }
                 else if (Features.IsSupported("skipdraw"))
                 {
                     ini.WriteValue("EmuCore/GS", "UserHacks_SkipDraw_Start", "0");


### PR DESCRIPTION
- correction for skipdraw feature in pcsx2 v1.6 ==> name of parameter in .ini is different
- Add one value in pcsx2 1.7 version for skipdraw for bully game (as per pcsx2 wiki : https://wiki.pcsx2.net/Bully
Skipdraw 6 : 6 can be used to correct an active bug "Misaligned depth blur effect"