### PR TITLE
Fuse core options + controls and yuzu cpu accuracy feature

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -2352,9 +2352,54 @@
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
     </core>
-    <core name="fuse">
+    <core name="fuse" features="padtokeyboard">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
+      <feature submenu="EMULATION" name="MACHINE TYPE" group="ADVANCED SETTINGS" value="fuse_machine" description="Define model, default to Spectrum 128K.">
+          <choice name="Spectrum 48K" value="Spectrum 48K"/>
+          <choice name="Spectrum 48K (NTSC)" value="Spectrum 48K (NTSC)"/>
+          <choice name="Spectrum 128K" value="Spectrum 128K"/>
+          <choice name="Spectrum +2" value="Spectrum +2"/>
+          <choice name="Spectrum +2A" value="Spectrum +2A"/>
+          <choice name="Spectrum +3" value="Spectrum +3"/>
+          <choice name="Spectrum +3e" value="Spectrum +3e"/>
+          <choice name="Spectrum SE" value="Spectrum SE"/>
+          <choice name="Timex TC2048" value="Timex TC2048"/>
+          <choice name="Timex TC2068" value="Timex TC2068"/>
+          <choice name="Timex TS2068" value="Timex TS2068"/>
+          <choice name="Spectrum 16K" value="Spectrum 16K"/>
+          <choice name="Pentagon 128K" value="Pentagon 128K"/>
+          <choice name="Pentagon 512K" value="Pentagon 512K"/>
+          <choice name="Pentagon 1024" value="Pentagon 1024"/>
+          <choice name="Scorpion 256K" value="Scorpion 256K"/>
+      </feature>
+      <feature submenu="CONTROLS" name="CONTROL TYPE" group="ADVANCED SETTINGS" value="zx_control_type" description="Use JOYSTICK ONLY for joystick games and KEYBOARD ONLY for keyboard games.">
+          <choice name="Joystick only" value="1"/>
+          <choice name="Keyboard only" value="2"/>
+          <choice name="Keyboard and Joystick" value="3"/>
+      </feature>
+      <feature submenu="CONTROLS" name="PLAYER 1 CONTROLLER TYPE" group="ADVANCED SETTINGS" value="zx_controller1" description="Sinclair 1 controller set to AUTO.">
+          <choice name="None" value="0"/>
+          <choice name="Retropad" value="1"/>
+          <choice name="Cursor Joystick" value="257"/>
+          <choice name="Kempston Joystick" value="513"/>
+          <choice name="Sinclair 1 Joystick" value="769"/>
+          <choice name="Sinclair 2 Joystick" value="1025"/>
+          <choice name="Timex 1 Joystick" value="1281"/>
+          <choice name="Timex 2 Joystick" value="1537"/>
+          <choice name="Fuller Joystick" value="1793"/>
+      </feature>
+      <feature submenu="CONTROLS" name="PLAYER 2 CONTROLLER TYPE" group="ADVANCED SETTINGS" value="zx_controller2" description="Sinclair 2 controller set to AUTO.">
+          <choice name="None" value="0"/>
+          <choice name="Retropad" value="1"/>
+          <choice name="Cursor Joystick" value="257"/>
+          <choice name="Kempston Joystick" value="513"/>
+          <choice name="Sinclair 1 Joystick" value="769"/>
+          <choice name="Sinclair 2 Joystick" value="1025"/>
+          <choice name="Timex 1 Joystick" value="1281"/>
+          <choice name="Timex 2 Joystick" value="1537"/>
+          <choice name="Fuller Joystick" value="1793"/>
+      </feature>
     </core>
     <core name="gambatte" features="cheevos, netplay">
       <feature name="PALETTE" group="ADVANCED SETTINGS" value="gambatte_gb_internal_palette" description="Select palette for colorizing GB games when COLORIZATION is set to 'internal'.">

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -4844,6 +4844,20 @@
       <choice name="5x (3600p/5400p)" value="6"/>
       <choice name="6x (4320p/6480p)" value="7"/>
     </feature>
+	<feature submenu="EMULATION" name="REGION" group="ADVANCED SETTINGS" value="yuzu_region_value" description="Force the region of the system.">
+      <choice name="JAPAN" value="0"/>
+      <choice name="USA" value="1"/>
+      <choice name="EUROPE" value="2"/>
+      <choice name="AUSTRALIA" value="3"/>
+      <choice name="CHINA" value="4"/>
+      <choice name="KOREA" value="5"/>
+      <choice name="TAIWAN" value="6"/>
+    </feature>
+	<feature submenu="EMULATION" name="CPU ACCURACY" group="ADVANCED SETTINGS" value="cpu_accuracy" description="Leave AUTO as default except the game requires specific setting.">
+      <choice name="ACCURATE" value="1"/>
+      <choice name="UNSAFE" value="2"/>
+      <choice name="PARANOID" value="3"/>
+    </feature>
     <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="videomode"/>
     <feature submenu="VISUAL RENDERING" name="ANTI ALIASING" group="ADVANCED SETTINGS" value="anti_aliasing" description="Set Anti Aliasing for rendered content.">
       <choice name="NONE" value="0"/>
@@ -4864,15 +4878,6 @@
     <feature submenu="CONTROLS" name="ENABLE MOTION" group="ADVANCED SETTINGS" value="yuzu_enable_motion" description="Can only be used if the controller is compatible with motion control.">
       <choice name="NO" value="false"/>
       <choice name="YES" value="true"/>
-    </feature>
-    <feature submenu="EMULATION" name="REGION" group="ADVANCED SETTINGS" value="yuzu_region_value" description="Force the region of the system.">
-      <choice name="JAPAN" value="0"/>
-      <choice name="USA" value="1"/>
-      <choice name="EUROPE" value="2"/>
-      <choice name="AUSTRALIA" value="3"/>
-      <choice name="CHINA" value="4"/>
-      <choice name="KOREA" value="5"/>
-      <choice name="TAIWAN" value="6"/>
     </feature>
   </emulator>
 </features>

--- a/batocera-systems/Resources/batocera-systems.json
+++ b/batocera-systems/Resources/batocera-systems.json
@@ -193,7 +193,15 @@
                                                     { "md5": "", "file": "bios/same_cdi/bios/cdimono1.zip"      },
                                                     { "md5": "", "file": "bios/same_cdi/bios/cdimono2.zip"      } ] },
 
-    "bbcmicro": { "name": "BBC", "biosFiles": [ { "md5": "", "file": "bios/bbcb.zip" } ] },
+    "bbcmicro": { "name": "BBC", "biosFiles": [     { "md5": "", "file": "bios/bbcb.zip"                  },
+                                                    { "md5": "", "file": "bios/bbc_acorn8271.zip"         },
+                                                    { "md5": "", "file": "bios/saa5050.zip"               },
+                                                    { "md5": "", "file": "bios/bbc_tube_80186.zip"        },
+                                                    { "md5": "", "file": "bios/bbcm.zip"                  },
+                                                    { "md5": "", "file": "bios/bbcmc.zip"                 },
+                                                    { "md5": "", "file": "bios/bbc_bitstik1.zip"          },
+                                                    { "md5": "", "file": "bios/bbc_bitstik2.zip"          },
+                                                    { "md5": "", "file": "bios/mame/samples/bbc.zip"      } ] },
 
     "crvision": { "name": "Creativision", "biosFiles":	[ { "md5": "", "file": "bios/crvision.zip"						},
                                                         { "md5": "", "file": "bios/mame/hash/crvision.xml"	} ] },

--- a/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
+++ b/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
@@ -328,6 +328,7 @@ namespace emulatorLauncher.libRetro
             ConfigureNeocd(retroarchConfig, coreSettings, system, core);
             Configurevicex64(retroarchConfig, coreSettings, system, core);
             ConfigureSwanStation(retroarchConfig, coreSettings, system, core);
+            ConfigureFuse(retroarchConfig, coreSettings, system, core);
 
             if (coreSettings.IsDirty)
                 coreSettings.Save(Path.Combine(RetroarchPath, "retroarch-core-options.cfg"), true);
@@ -1858,6 +1859,14 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "duckstation_GPU.MSAA", "msaa", "1");
             BindFeature(coreSettings, "duckstation_GPU.ScaledDithering", "scaled_dithering", "true");
             BindFeature(coreSettings, "duckstation_GPU.TrueColor", "truecolor", "false");
+        }
+
+        private void ConfigureFuse(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
+        {
+            if (core != "fuse")
+                return;
+
+            BindFeature(coreSettings, "fuse_machine", "fuse_machine", "Spectrum 128K");
         }
 
         #region Input remaps

--- a/emulatorLauncher/Generators/LibRetro.Generator.cs
+++ b/emulatorLauncher/Generators/LibRetro.Generator.cs
@@ -273,6 +273,7 @@ namespace emulatorLauncher.libRetro
             retroarchConfig["input_libretro_device_p1"] = coreToP1Device.ContainsKey(core) ? coreToP1Device[core] : "1";
             retroarchConfig["input_libretro_device_p2"] = coreToP2Device.ContainsKey(core) ? coreToP2Device[core] : "1";
 
+            //psx specifics
             if (Controllers.Count > 2 && (core == "snes9x_next" || core == "snes9x"))
                 retroarchConfig["input_libretro_device_p2"] = "257";
 
@@ -284,8 +285,37 @@ namespace emulatorLauncher.libRetro
                     retroarchConfig["input_libretro_device_p2"] = SystemConfig["psxcontroller2"];
             }
 
+            //fuse specifics
+            if (core == "fuse")
+            {
+                //player 1 controller - sinclair 1 controller used as default as used by most games
+                if (SystemConfig.isOptSet("zx_controller1") && !string.IsNullOrEmpty(SystemConfig["zx_controller1"])) 
+                    retroarchConfig["input_libretro_device_p1"] = SystemConfig["zx_controller1"];
+                else if (Features.IsSupported("zx_controller1"))
+                    retroarchConfig["input_libretro_device_p1"] = "769";
+                
+                //player 2 controller - sinclair 2 as default
+                if (SystemConfig.isOptSet("zx_controller2") && !string.IsNullOrEmpty(SystemConfig["zx_controller2"]))
+                    retroarchConfig["input_libretro_device_p2"] = SystemConfig["zx_controller2"];
+                else if (Features.IsSupported("zx_controller2"))
+                    retroarchConfig["input_libretro_device_p2"] = "1025";
+
+                //if using keyboard only option, disable controllers and use keyboard as device_p3 as stated in libretro core documentation
+                //3 options : keyboard only (disables joysticks), joysticks only (disables keyboard) or keyboard + joysticks (add keyboard as p3)
+                if (SystemConfig.isOptSet("zx_control_type") && !string.IsNullOrEmpty(SystemConfig["zx_control_type"]) && SystemConfig["zx_control_type"] == "2")
+                {
+                    retroarchConfig["input_libretro_device_p1"] = "0";
+                    retroarchConfig["input_libretro_device_p2"] = "0";
+                    retroarchConfig["input_libretro_device_p3"] = "259";
+                }
+                else if (Features.IsSupported("zx_control_type") && !string.IsNullOrEmpty(SystemConfig["zx_control_type"]) && SystemConfig["zx_control_type"] == "3")
+                    retroarchConfig["input_libretro_device_p3"] = "259";
+                else if (Features.IsSupported("zx_control_type") && !string.IsNullOrEmpty(SystemConfig["zx_control_type"]) && SystemConfig["zx_control_type"] == "1")
+                    retroarchConfig["input_libretro_device_p3"] = "0";
+            }
+
             if (LibretroControllers.WriteControllersConfig(retroarchConfig, system, core))
-                UseEsPadToKey = false;
+            UseEsPadToKey = false;
 
             // Core, services & bezel configs
             ConfigureRetroachievements(retroarchConfig);

--- a/emulatorLauncher/Generators/LibRetro.Generator.cs
+++ b/emulatorLauncher/Generators/LibRetro.Generator.cs
@@ -315,7 +315,7 @@ namespace emulatorLauncher.libRetro
             }
 
             if (LibretroControllers.WriteControllersConfig(retroarchConfig, system, core))
-            UseEsPadToKey = false;
+                UseEsPadToKey = false;
 
             // Core, services & bezel configs
             ConfigureRetroachievements(retroarchConfig);

--- a/emulatorLauncher/Generators/Yuzu.Generator.cs
+++ b/emulatorLauncher/Generators/Yuzu.Generator.cs
@@ -177,6 +177,18 @@ namespace emulatorLauncher
                     ini.WriteValue("Renderer", "scaling_filter\\default", "true");
                     ini.WriteValue("Renderer", "scaling_filter", "1");
                 }
+
+                //CPU accuracy (auto except if the user chooses otherwise)
+                if (SystemConfig.isOptSet("cpu_accuracy") && !string.IsNullOrEmpty(SystemConfig["cpu_accuracy"]) && SystemConfig["cpu_accuracy"] != "0")
+                {
+                    ini.WriteValue("Cpu", "cpu_accuracy\\default", "false");
+                    ini.WriteValue("Cpu", "cpu_accuracy", SystemConfig["cpu_accuracy"]);
+                }
+                else
+                {
+                    ini.WriteValue("Cpu", "cpu_accuracy\\default", "true");
+                    ini.WriteValue("Cpu", "cpu_accuracy", "0");
+                }
             }
         }
 


### PR DESCRIPTION
**For yuzu** : 
add cpu accuracy feature

**For FUSE:**
Add Machine feature.

For controls:
refer to https://docs.libretro.com/library/fuse/#controllers-usage

> There are some conflicts in the way the input devices interact because of the use of the physical keyboard keys as joystick buttons. For a good gaming experience, set the user device types as follows:
    For joystick games: Set user 1 to a joystick type. Optionally, set user 2 to another joystick type (local cooperative games). Set user 3 to none. This way, you can use L1 as RETURN, R1 as SPACE, and SELECT to bring the embedded keyboard.
    For keyboard games: Set users 1 and 2 to none, and user 3 to Sinclair Keyboard. You won't have any joystick and the embedded keyboard won't work, but the entire physical keyboard will be available for you to type in those text adventure commands.