### PR TITLE
add game focus to retroarch global features & roland sc-88 sound font, remove rewind feature for dos

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -285,6 +285,10 @@
       <choice name="ON" value="0"/>
       <choice name="OFF" value="1"/>
     </feature>
+	<feature name="GAME FOCUS" value="GameFocus" description="Controls are managed by the game or by the emulator. 'Auto' will enable the option if current core implement frontend keyboard fallback. Toggle with 'Scroll Lock' key.">
+      <choice name="OFF" value="0"/>
+      <choice name="ON" value="1"/>
+    </feature>
     <feature name="VIDEO" value="video_driver" description="The driver 'vulkan' will generally offer better performance if hardware compatible. Some libretro cores will force the choosen driver.">
       <choice name="opengl" value="gl"/>
       <choice name="opengl core" value="glcore"/>
@@ -362,6 +366,7 @@
     <sharedFeature submenu="DRIVERS" group="RETROARCH OPTIONS" value="audio_driver"/>
     <sharedFeature submenu="DRIVERS" group="RETROARCH OPTIONS" value="input_driver"/>
     <!-- CONTROLS OPTIONS -->
+    <sharedFeature submenu="CONTROLS" group="RETROARCH OPTIONS" value="GameFocus"/>
   </globalFeatures>
   <!-- SHARED FEATURES -->
   <!-- RETROARCH -->
@@ -412,6 +417,7 @@
     <!--
 	<sharedFeature submenu="CONTROLS" group="ADVANCED SETTINGS" value="use_guns"/>
 	-->
+    <sharedFeature submenu="CONTROLS" group="ADVANCED SETTINGS" value="GameFocus"/>
     <!-- LIBRETRO CORES FEATURES -->
     <core name="atari2600" features="cheevos, netplay">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
@@ -730,6 +736,7 @@
       <feature submenu="AUDIO" name="MIDI OUTPUT" group="ADVANCED SETTINGS" value="midi" description="Select the soundfont file or interface used for MIDI output.">
         <choice name="NO" value="disabled"/>
         <choice name="ROLAND_SC-55" value="scummvm/extra/Roland_SC-55.sf2"/>
+        <choice name="ROLAND_SC-88" value="scummvm/extra/Roland_SC-88.sf2"/>
         <choice name="FRONTEND MIDI DRIVER" value="frontend"/>
       </feature>
       <feature submenu="AUDIO" name="GRAVIS ULTRASOUND" group="ADVANCED SETTINGS" value="gus" description="Enable GUS emulation. Settings are fixed to port 240, IRQ 5, DMA 3.">

--- a/emulatorLauncher/Generators/LibRetro.Generator.cs
+++ b/emulatorLauncher/Generators/LibRetro.Generator.cs
@@ -233,7 +233,9 @@ namespace emulatorLauncher.libRetro
             BindFeature(retroarchConfig, "screen_orientation", "RotateScreen", "0"); // screen orientation
             BindFeature(retroarchConfig, "crt_switch_resolution", "CRTSwitch", "0"); // CRT Switch
             BindFeature(retroarchConfig, "crt_switch_resolution_super", "CRTSuperRes", "0"); // CRT Resolution
-            
+
+            BindFeature(retroarchConfig, "input_auto_game_focus", "GameFocus", "2"); // Game Focus
+
             // Stats
             if (SystemConfig.isOptSet("DrawStats"))
             {
@@ -1253,7 +1255,7 @@ namespace emulatorLauncher.libRetro
         static List<string> ratioIndexes = new List<string> { "4/3", "16/9", "16/10", "16/15", "21/9", "1/1", "2/1", "3/2", "3/4", "4/1", "4/4", "5/4", "6/5", "7/9", "8/3",
                 "8/7", "19/12", "19/14", "30/17", "32/9", "config", "squarepixel", "core", "custom", "full" };
 
-        static List<string> systemNoRewind = new List<string>() { "nds", "3ds", "sega32x", "wii", "gamecube", "gc", "psx", "zxspectrum", "odyssey2", "n64", "dreamcast", "atomiswave", "naomi", "naomi2", "neogeocd", "saturn", "mame", "hbmame", "fbneo" };
+        static List<string> systemNoRewind = new List<string>() { "nds", "3ds", "sega32x", "wii", "gamecube", "gc", "psx", "zxspectrum", "odyssey2", "n64", "dreamcast", "atomiswave", "naomi", "naomi2", "neogeocd", "saturn", "mame", "hbmame", "fbneo", "dos" };
         static List<string> systemNoRunahead = new List<string>() { "nds", "3ds", "sega32x", "wii", "gamecube", "n64", "dreamcast", "atomiswave", "naomi", "naomi2", "neogeocd", "saturn" };
         
         static Dictionary<string, string> coreToP1Device = new Dictionary<string, string>() { { "atari800", "513" }, { "cap32", "513" }, { "81", "257" }, { "fuse", "513" } };


### PR DESCRIPTION
minor optimizations:
add game focus global feature for retroarch and set it on "detect" by default
remove rewind feature because with dosbox it create and infinite loop of annoynig savestate error messages

