### PR TITLE
corrections in genesis_plus_gx core for multiple system names

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -1185,7 +1185,13 @@
         <choice name="S-VIDEO" value="s-video"/>
         <choice name="RGB" value="rgb"/>
       </feature>
-      <system name="megadrive, megadrive-msu">
+      <system name="megadrive">
+        <feature submenu="VIDEO" name="LCD GHOSTING FILTER" group="ADVANCED SETTINGS" value="lcd_filter" description="Mimics the display characteristics of the Game Gear and Nomad LCD panels.">
+          <choice name="NO" value="disabled"/>
+          <choice name="YES" value="enabled"/>
+        </feature>
+	  </system>
+	  <system name="megadrive-msu">
         <feature submenu="VIDEO" name="LCD GHOSTING FILTER" group="ADVANCED SETTINGS" value="lcd_filter" description="Mimics the display characteristics of the Game Gear and Nomad LCD panels.">
           <choice name="NO" value="disabled"/>
           <choice name="YES" value="enabled"/>
@@ -1197,7 +1203,24 @@
           <choice name="YES" value="enabled"/>
         </feature>
       </system>
-      <system name="megadrive, megadrive-msu">
+      <system name="megadrive">
+        <feature submenu="AUDIO" name="AUDIO FILTER" group="ADVANCED SETTINGS" value="audio_filter" description="Better simulate the characteristic sound of a Megadrive/Genesis 1.">
+          <choice name="NO" value="disabled"/>
+          <choice name="YES" value="low-pass"/>
+        </feature>
+        <feature submenu="AUDIO" name="MEGADRIVE/GENESIS FM" group="ADVANCED SETTINGS" value="ym2612" description="Select method used to emulate the FM synthetiser.">
+          <choice name="MAME (YM2612)" value="mame (ym2612)"/>
+          <choice name="MAME (ASIC YM3438)" value="mame (asic ym3438)"/>
+          <choice name="MAME (ENHANCED YM3438)" value="mame (enhanced ym3438)"/>
+          <choice name="NUKED (YM2612)" value="nuked (ym2612)"/>
+          <choice name="NUKED (YM3438)" value="nuked (ym3438)"/>
+        </feature>
+        <feature submenu="AUDIO" name="CD ADD-ON" group="ADVANCED SETTINGS" value="genesis_plus_gx_add_on" description="Specifies wich add-on to use for audio CD playback with patched MD games.">
+          <choice name="Mega CD" value="megacd"/>
+          <choice name="Mega SD" value="megasd"/>
+        </feature>
+      </system>
+	  <system name="megadrive-msu">
         <feature submenu="AUDIO" name="AUDIO FILTER" group="ADVANCED SETTINGS" value="audio_filter" description="Better simulate the characteristic sound of a Megadrive/Genesis 1.">
           <choice name="NO" value="disabled"/>
           <choice name="YES" value="low-pass"/>
@@ -1248,7 +1271,15 @@
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>
       </feature>
-      <system name="megadrive, megadrive-msu">
+      <system name="megadrive">
+        <feature submenu="EMULATION" name="CARTRIDGE LOCK-ON" group="ADVANCED SETTINGS" value="lock_on" description="This option specifies which lock-on cartridge to emulate.">
+          <choice name="NO" value="disabled"/>
+          <choice name="GAME GENIE" value="game genie"/>
+          <choice name="ACTION REPLAY" value="action replay (pro)"/>
+          <choice name="SONIC AND KNUCKLES" value="sonic &amp; knuckles"/>
+        </feature>
+      </system>
+	  <system name="megadrive-msu">
         <feature submenu="EMULATION" name="CARTRIDGE LOCK-ON" group="ADVANCED SETTINGS" value="lock_on" description="This option specifies which lock-on cartridge to emulate.">
           <choice name="NO" value="disabled"/>
           <choice name="GAME GENIE" value="game genie"/>


### PR DESCRIPTION
fix options not showing for megadrive and megadrive msu