### PR TITLE
Dolphin sensorbar, supermodel index, duckstation savespath, apple2gs bios

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -3557,7 +3557,7 @@
         <choice name="DIRECTX 12" value="D3D12"/>
       </feature>
       <!-- CONTROLS -->
-      <feature submenu="CONTROLS" name="INVERT A AND B" group="ADVANCED SETTINGS" value="gamepadbuttons" order="90">
+      <feature submenu="CONTROLS" name="INVERT A AND B" group="ADVANCED SETTINGS" value="gamepadbuttons" description="Invert A/B and X/Y buttons.">
         <choice name="NO" value="0"/>
         <choice name="YES" value="1"/>
       </feature>
@@ -3638,73 +3638,73 @@
         <choice name="Nederlands" value="6"/>
         <choice name="Japanese" value="0"/>
       </feature>
-      <feature submenu="EMULATION" name="ENABLE CHEATS" group="ADVANCED SETTINGS" value="enable_cheats" description="Enable the effects of the chosen Action Replay and Gecko codes for a game." order="89">
+      <feature submenu="EMULATION" name="ENABLE CHEATS" group="ADVANCED SETTINGS" value="enable_cheats" description="Enable the effects of the chosen Action Replay and Gecko codes for a game.">
         <choice name="NO" value="0"/>
         <choice name="YES" value="1"/>
       </feature>
-      <feature submenu="EMULATION" name="MEMORY MANAGEMENT UNIT" group="ADVANCED SETTINGS" value="enable_mmu" description="Enable the Memory Management Unit. Required for some games." order="89">
+      <feature submenu="EMULATION" name="MEMORY MANAGEMENT UNIT" group="ADVANCED SETTINGS" value="enable_mmu" description="Enable the Memory Management Unit. Required for some games.">
         <choice name="NO" value="0"/>
         <choice name="YES" value="1"/>
       </feature>
-      <feature submenu="EMULATION" name="DUAL CORE CPU THREAD" group="ADVANCED SETTINGS" value="CPUThread" description="Run games faster. A powerful option for gaining performance that has no downsides some of the time. May cause various random issues caused by splitting the CPU and GPU threads onto different cores." order="89">
+      <feature submenu="EMULATION" name="DUAL CORE CPU THREAD" group="ADVANCED SETTINGS" value="CPUThread" description="Run games faster. A powerful option for gaining performance that has no downsides some of the time. May cause various random issues caused by splitting the CPU and GPU threads onto different cores.">
         <choice name="NO" value="0"/>
         <choice name="YES" value="1"/>
       </feature>
-      <feature submenu="EMULATION" name="FAST DISK SPEED" group="ADVANCED SETTINGS" value="enable_fastdisc" description="Improve the loading of discs of the emulated game." order="89">
+      <feature submenu="EMULATION" name="FAST DISK SPEED" group="ADVANCED SETTINGS" value="enable_fastdisc" description="Improve the loading of discs of the emulated game.">
         <choice name="NO" value="0"/>
         <choice name="YES" value="1"/>
       </feature>
-      <feature submenu="EMULATION" name="SKIP EFB ACCESS (HACK)" group="ADVANCED SETTINGS" value="EFBEmulateFormatChanges" description="Improve performance in some games but can disable graphical effects and gameplay related features." order="89">
+      <feature submenu="EMULATION" name="SKIP EFB ACCESS (HACK)" group="ADVANCED SETTINGS" value="EFBEmulateFormatChanges" description="Improve performance in some games but can disable graphical effects and gameplay related features.">
         <choice name="NO" value="False"/>
         <choice name="YES" value="True"/>
       </feature>
-      <feature submenu="EMULATION" name="IGNORE EFB FORMAT (HACK)" group="ADVANCED SETTINGS" value="EFBEmulateFormatChanges" description="Improve performance in many game. Disabling this may avoid graphical defect in some other games." order="89">
+      <feature submenu="EMULATION" name="IGNORE EFB FORMAT (HACK)" group="ADVANCED SETTINGS" value="EFBEmulateFormatChanges" description="Improve performance in many game. Disabling this may avoid graphical defect in some other games.">
         <choice name="YES" value="True"/>
         <choice name="NO" value="False"/>
       </feature>
-      <feature submenu="EMULATION" name="STORE EFB COPIES (HACK)" group="ADVANCED SETTINGS" value="EFBCopies" description="Many games need copies to textures only, but if you're seeing blacked out or missing graphics, you might need to choose copies to RAM." order="89">
+      <feature submenu="EMULATION" name="STORE EFB COPIES (HACK)" group="ADVANCED SETTINGS" value="EFBCopies" description="Many games need copies to textures only, but if you're seeing blacked out or missing graphics, you might need to choose copies to RAM.">
         <choice name="TO TEXTURE" value="efb_to_texture_defer"/>
         <choice name="TO TEXTURE AND RAM" value="efb_to_ram_defer"/>
         <choice name="DON'T DEFER COPIES TO RAM" value="efb_to_ram"/>
       </feature>
-      <feature submenu="EMULATION" name="SCALED EFB COPY (HACK)" group="ADVANCED SETTINGS" value="EFBScaledCopy" description="Greatly inscrease the quality of textures generated using render-to-texture effects. Enabled by default. Disabling it may avoid crashes for games using custom textures." order="89">
+      <feature submenu="EMULATION" name="SCALED EFB COPY (HACK)" group="ADVANCED SETTINGS" value="EFBScaledCopy" description="Greatly inscrease the quality of textures generated using render-to-texture effects. Enabled by default. Disabling it may avoid crashes for games using custom textures.">
         <choice name="YES" value="True"/>
         <choice name="NO" value="False"/>
       </feature>
-      <feature submenu="EMULATION" name="FORCE TEXTURES FILTERING" group="ADVANCED SETTINGS" value="ForceFiltering" description="Filter all textures. Including any that the game explicitly sets as unfiltered. Enabled by default." order="89">
+      <feature submenu="EMULATION" name="FORCE TEXTURES FILTERING" group="ADVANCED SETTINGS" value="ForceFiltering" description="Filter all textures. Including any that the game explicitly sets as unfiltered. Enabled by default.">
         <choice name="NO" value="False"/>
         <choice name="YES" value="True"/>
       </feature>
-      <feature submenu="EMULATION" name="PERFORMANCE MODE" group="ADVANCED SETTINGS" value="perf_hacks" description="Improves the emulation performance at the cost of accuracy." order="89">
+      <feature submenu="EMULATION" name="PERFORMANCE MODE" group="ADVANCED SETTINGS" value="perf_hacks" description="Improves the emulation performance at the cost of accuracy.">
         <choice name="NO" value="0"/>
         <choice name="YES" value="1"/>
       </feature>
       <!-- USER INTERFACE -->
-      <feature submenu="USER INTERFACE" name="NOTIFICATIONS" group="ADVANCED SETTINGS" value="OnScreenDisplayMessages" description="Display or not on-screen notifications." order="90">
+      <feature submenu="USER INTERFACE" name="NOTIFICATIONS" group="ADVANCED SETTINGS" value="OnScreenDisplayMessages" description="Display or not on-screen notifications.">
         <choice name="NO" value="0"/>
         <choice name="YES" value="1"/>
       </feature>
-      <feature submenu="USER INTERFACE" name="SHOW FPS" group="ADVANCED SETTINGS" value="DrawFramerate" description="Shows the number of frames redered per seconds as a measure of emulation speed." order="90">
+      <feature submenu="USER INTERFACE" name="SHOW FPS" group="ADVANCED SETTINGS" value="DrawFramerate" description="Shows the number of frames redered per seconds as a measure of emulation speed.">
         <choice name="NO" value="0"/>
         <choice name="YES" value="1"/>
       </feature>
       <!-- DRIVERS -->
-      <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="gfxbackend" description="Select which graphics API to use internally." order="90">
+      <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="gfxbackend" description="Select which graphics API to use internally.">
         <choice name="OPENGL" value="OGL"/>
         <choice name="VULKAN" value="Vulkan"/>
         <choice name="DIRECTX 11" value="D3D"/>
         <choice name="DIRECTX 12" value="D3D12"/>
       </feature>
       <!-- CONTROLS -->
-      <feature submenu="CONTROLS" name="INVERT A AND B" group="ADVANCED SETTINGS" value="gamepadbuttons" order="90">
+      <feature submenu="CONTROLS" name="INVERT A AND B" group="ADVANCED SETTINGS" value="gamepadbuttons" description="Invert A/B and X/Y buttons.">
         <choice name="NO" value="0"/>
         <choice name="YES" value="1"/>
       </feature>
-      <feature submenu="CONTROLS" name="WIIMOTE TYPE" group="ADVANCED SETTINGS" value="emulatedwiimotes" order="90">
+      <feature submenu="CONTROLS" name="WIIMOTE TYPE" group="ADVANCED SETTINGS" value="emulatedwiimotes">
         <choice name="EMULATED" value="1"/>
         <choice name="REAL" value="0"/>
       </feature>
-      <feature submenu="CONTROLS" name="EMULATED DEVICES" group="ADVANCED SETTINGS" value="controller_mode" description="Emulate a specific motion control. The '/' means the action for L-stick/R-stick." order="90">
+      <feature submenu="CONTROLS" name="EMULATED DEVICES" group="ADVANCED SETTINGS" value="controller_mode" description="Emulate a specific motion control. The '/' means the action for L-stick/R-stick.">
         <choice name="CLASSIC CONTROLLER" value="cc"/>
         <choice name="WIIMOTE: HORIZONTAL" value="side"/>
         <choice name="WIIMOTE: CURSOR/SWING" value="is"/>
@@ -3719,6 +3719,10 @@
         <choice name="WIIMOTE: NUNCHUK/SWING" value="ns"/>
         <choice name="WIIMOTE: TILT/NUNCHUK" value="tn"/>
         <choice name="WIIMOTE: NUNCHUK/TILT" value="nt"/>
+      </feature>
+      <feature submenu="CONTROLS" name="SENSOR BAR POSITION" group="ADVANCED SETTINGS" value="sensorbar_position" description="If you are using real Wiimotes with a Sensor Bar, set the right position of the Sensor Bar for better precision.">
+        <choice name="BOTTOM" value="0"/>
+        <choice name="TOP" value="1"/>
       </feature>
     </system>
   </emulator>

--- a/batocera-systems/Resources/batocera-systems.json
+++ b/batocera-systems/Resources/batocera-systems.json
@@ -11,6 +11,8 @@
                                                       { "md5": "ce6a86574d0c9de9075705f14e99d090", "file": "bios/ProSystem.dat"     } ] },
 
 	"atarist":   { "name": "Atari ST", "biosFiles":   [ { "md5": "c1c57ce48e8ee4135885cee9e63a68a2", "file": "bios/tos.img"           } ] },
+    
+    "apple2gs":   { "name": "Apple II GS", "biosFiles":   [ { "md5": "20a0334c447cb069a040ae5be1d938df", "file": "bios/APPLE2GS.ROM"           } ] },
 
   "lynx":      { "name": "Lynx", "biosFiles":       [ { "md5": "fcd403db69f54290b51035d82f835e7b", "file": "bios/lynxboot.img"	  } ] },
 

--- a/emulatorLauncher/Generators/Dolphin.Generator.cs
+++ b/emulatorLauncher/Generators/Dolphin.Generator.cs
@@ -365,26 +365,40 @@ namespace emulatorLauncher
                 return;
 
             int langId = 1;
+            int barPos = 0;
 
             if (SystemConfig.isOptSet("wii_language") && !string.IsNullOrEmpty(SystemConfig["wii_language"]))
                 langId = SystemConfig["wii_language"].ToInteger();
             else
                 langId = getWiiLangFromEnvironment();
 
+            if (SystemConfig.isOptSet("sensorbar_position") && !string.IsNullOrEmpty(SystemConfig["sensorbar_position"]))
+                barPos = SystemConfig["sensorbar_position"].ToInteger();
+
             // Read SYSCONF file
             byte[] bytes = File.ReadAllBytes(path);
 
-            // Search IPL.LNG pattern and get index
-            byte[] pattern = new byte[] { 0x49, 0x50, 0x4C, 0x2E, 0x4C, 0x4E, 0x47 };
-            int index = bytes.IndexOf(pattern);
-            if (index >= 0 && index + pattern.Length + 1 < bytes.Length)
+            // Search IPL.LNG pattern and replace with target language
+            byte[] langPattern = new byte[] { 0x49, 0x50, 0x4C, 0x2E, 0x4C, 0x4E, 0x47 };
+            int index = bytes.IndexOf(langPattern);
+            if (index >= 0 && index + langPattern.Length + 1 < bytes.Length)
             {
                 var toSet = new byte[] { 0x49, 0x50, 0x4C, 0x2E, 0x4C, 0x4E, 0x47, (byte)langId };
                 for (int i = 0; i < toSet.Length; i++)
                     bytes[index + i] = toSet[i];
-
-                File.WriteAllBytes(path, bytes);
             }
+
+            // Search BT.BAR pattern and replace with target position
+            byte[] barPositionPattern = new byte[] { 0x42, 0x54, 0x2E, 0x42, 0x41, 0x52 };
+            int index2 = bytes.IndexOf(barPositionPattern);
+            if (index >= 0 && index + langPattern.Length + 1 < bytes.Length)
+            {
+                var toSet = new byte[] { 0x42, 0x54, 0x2E, 0x42, 0x41, 0x52, (byte)barPos };
+                for (int i = 0; i < toSet.Length; i++)
+                    bytes[index2 + i] = toSet[i];
+            }
+
+            File.WriteAllBytes(path, bytes);
         }
 
         private void SetupGeneralConfig(string path, string system)

--- a/emulatorLauncher/Generators/Duckstation.Generator.cs
+++ b/emulatorLauncher/Generators/Duckstation.Generator.cs
@@ -96,17 +96,9 @@ namespace emulatorLauncher
                     if (!string.IsNullOrEmpty(biosPath))
                         ini.WriteValue("BIOS", "SearchDirectory", biosPath.Replace("\\", "\\\\"));
 
-                    string savesPath = AppConfig.GetFullPath("saves");
+                    string savesPath = Path.Combine(AppConfig.GetFullPath("saves"), "psx", "duckstation", "memcards");
                     if (!string.IsNullOrEmpty(savesPath))
-                    {
-                        savesPath = Path.Combine(savesPath, "psx", Path.GetFileName(_path)) + "\\\\" + "memcards";
-
-                        if (!Directory.Exists(savesPath))
-                            try { Directory.CreateDirectory(savesPath); }
-                            catch { }
-
                         ini.WriteValue("MemoryCards", "Directory", savesPath.Replace("\\", "\\\\"));
-                    }
 
                     if (SystemConfig.isOptSet("ratio") && !string.IsNullOrEmpty(SystemConfig["ratio"]))
                         ini.WriteValue("Display", "AspectRatio", SystemConfig["ratio"]);

--- a/emulatorLauncher/Generators/Model3.Controllers.cs
+++ b/emulatorLauncher/Generators/Model3.Controllers.cs
@@ -60,11 +60,11 @@ namespace emulatorLauncher
             //initialize controller index, supermodel uses directinput controller index (+1)
             //only index of player 1 is initialized as there might be only 1 controller at that point
             int j2index = -1;
-            int j1index = c1.SdlController.Index + 1;
+            int j1index = c1.SdlController !=null ? c1.SdlController.Index : c1.DeviceIndex;
 
             //If a secod controller is connected, get controller index of player 2, if there is no 2nd controller, just increment the index
             if (c2 != null && c2.Config != null)
-                j2index = c2.SdlController.Index + 1;
+                j2index = c2.SdlController != null ? c2.SdlController.Index : c2.DeviceIndex;
             else
                 j2index = j1index + 1;
 

--- a/emulatorLauncher/Generators/Model3.Controllers.cs
+++ b/emulatorLauncher/Generators/Model3.Controllers.cs
@@ -60,11 +60,11 @@ namespace emulatorLauncher
             //initialize controller index, supermodel uses directinput controller index (+1)
             //only index of player 1 is initialized as there might be only 1 controller at that point
             int j2index = -1;
-            int j1index = c1.DirectInput.DeviceIndex + 1;
+            int j1index = c1.SdlController.Index + 1;
 
             //If a secod controller is connected, get controller index of player 2, if there is no 2nd controller, just increment the index
             if (c2 != null && c2.Config != null)
-                j2index = c2.DirectInput.DeviceIndex + 1;
+                j2index = c2.SdlController.Index + 1;
             else
                 j2index = j1index + 1;
 


### PR DESCRIPTION
Add sysconf sensorbar position feature for dolphin wii.
Supermodel use correct index.
Apple2GS add missing bios check
Fix duckstation savespath (we were changing 2x \\ to \\\\)