### PR TITLE
vice (xvic, x64, xplus4) features and ryujinx buttons inversion feature

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -2438,28 +2438,6 @@
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
     </core>
-    <core name="vice_x64">
-      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
-      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
-      <feature submenu="VISUAL RENDERING" name="ZOOM MODE" group="ADVANCED SETTINGS" value="crop" description="Crops the borders to show or hide border graphics.">
-        <choice name="DISABLED" value="disabled"/>
-        <choice name="SMALL" value="small"/>
-        <choice name="MEDIUM" value="medium"/>
-        <choice name="MAXIMUM" value="maximum"/>
-      </feature>
-      <feature submenu="EMULATION" name="MODEL TYPE" group="ADVANCED SETTINGS" value="c64_model" description="Define system region (PAL vs NTSC).">
-        <choice name="C64 PAL auto" value="C64 PAL auto"/>
-        <choice name="C64 NTSC auto" value="C64 NTSC auto"/>
-        <choice name="C64 PAL" value="C64 PAL"/>
-        <choice name="C64 NTSC" value="C64 NTSC"/>
-        <choice name="C64 GS PAL" value="C64 GS PAL"/>
-        <choice name="C64 JAP NTSC" value="C64 JAP NTSC"/>
-      </feature>
-      <feature submenu="EMULATION" name="WARP BOOST" group="ADVANCED SETTINGS" value="warp_boost" description="Make warp mode much faster by changing SID emulation to 'FastSID' while warping.">
-        <choice name="ENABLED" value="enabled"/>
-        <choice name="DISABLED" value="disabled"/>
-      </feature>
-    </core>
     <core name="vice_x64sc">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
@@ -2468,50 +2446,57 @@
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
     </core>
-    <core name="vice_xvic">
+    <core name="vice_x64">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
-      <system name="c20">
-        <feature submenu="EMULATION" name="MODEL TYPE" group="ADVANCED SETTINGS" value="vic20_model" description="Define system region (PAL vs NTSC).">
-          <choice name="VIC-20 PAL Auto" value="VIC20 PAL auto"/>
-          <choice name="VIC-20 NTSC Auto" value="VIC20 NTSC auto"/>
-          <choice name="VIC-20 PAL" value="VIC20 PAL"/>
-          <choice name="VIC-20 NTSC" value="VIC20 NTSC"/>
-          <choice name="Super VIC NTSC" value="VIC21"/>
-        </feature>
-        <feature submenu="EMULATION" name="MEMORY EXPANSION" group="ADVANCED SETTINGS" value="vic20_memexpansion">
-          <choice name="NONE" value="Disabled"/>
-          <choice name="3kB" value="3kB"/>
-          <choice name="8kB" value="8kB"/>
-          <choice name="16kB" value="16kB"/>
-          <choice name="24kB" value="24kB"/>
-          <choice name="35kB" value="35kB"/>
-        </feature>
-        <feature submenu="VISUAL RENDERING" name="COLOR PALETTE" group="ADVANCED SETTINGS" value="vic20_palette" description="Choose which color palette is going to be used.">
-          <choice name="Internal" value="default"/>
-          <choice name="Colodore" value="colodore_vic"/>
-          <choice name="Mike (PAL)" value="mike-pal"/>
-          <choice name="Mike (NTSC)" value="mike-ntsc"/>
-          <choice name="VICE" value="vice"/>
-        </feature>
-      </system>
+      <feature submenu="VISUAL RENDERING" name="CROP" group="ADVANCED SETTINGS" value="vice_crop" description="Crops the borders to show or hide border graphics.">
+        <choice name="DISABLED" value="disabled"/>
+        <choice name="SMALL" value="small"/>
+        <choice name="MEDIUM" value="medium"/>
+        <choice name="MAXIMUM" value="maximum"/>
+      </feature>
+      <feature submenu="EMULATION" name="MODEL TYPE" group="ADVANCED SETTINGS" value="c64_model" description="Define system region (PAL vs NTSC).">
+        <choice name="C64 PAL auto" value="C64 PAL auto"/>
+        <choice name="C64 NTSC auto" value="C64 NTSC auto"/>
+        <choice name="C64C PAL auto" value="C64C PAL auto"/>
+        <choice name="C64C NTSC auto" value="C64C NTSC auto"/>
+        <choice name="C64 PAL" value="C64 PAL"/>
+        <choice name="C64 NTSC" value="C64 NTSC"/>
+        <choice name="C64C PAL" value="C64C PAL"/>
+        <choice name="C64C NTSC" value="C64C NTSC"/>
+        <choice name="C64SX PAL" value="C64SX PAL"/>
+        <choice name="C64SX NTSC" value="C64SX NTSC"/>
+        <choice name="C64 GS PAL" value="C64 GS PAL"/>
+        <choice name="C64 JAP NTSC" value="C64 JAP NTSC"/>
+      </feature>
+      <feature submenu="EMULATION" name="MEMORY EXPANSION" group="ADVANCED SETTINGS" value="vice_ram_expansion_unit">
+        <choice name="NONE" value="none"/>
+        <choice name="128kB" value="128kB"/>
+        <choice name="256kB" value="256kB"/>
+        <choice name="512kB" value="512kB"/>
+        <choice name="1024kB" value="1024kB"/>
+        <choice name="2048kB" value="2048kB"/>
+        <choice name="4096kB" value="4096kB"/>
+        <choice name="8192kB" value="8192kB"/>
+        <choice name="16384kB" value="16384kB"/>
+      </feature>
+      <feature submenu="EMULATION" name="WARP BOOST" group="ADVANCED SETTINGS" value="warp_boost" description="Make warp mode much faster by changing SID emulation to 'FastSID' while warping.">
+        <choice name="ENABLED" value="enabled"/>
+        <choice name="DISABLED" value="disabled"/>
+      </feature>
       <feature submenu="VISUAL RENDERING" name="PIXEL ASPECT RATIO" group="ADVANCED SETTINGS" value="vice_aspect_ratio">
         <choice name="Automatic" value="auto"/>
         <choice name="PAL" value="pal"/>
         <choice name="NTSC" value="ntsc"/>
         <choice name="1:1" value="raw"/>
       </feature>
-      <feature submenu="VISUAL RENDERING" name="COLOR DEPTH" group="ADVANCED SETTINGS" value="vice_gfx_colors">
-        <choice name="Thousands (16-bit)" value="16bit"/>
-        <choice name="Millions (24-bit)" value="24bit"/>
+      <feature submenu="VISUAL RENDERING" name="CROP" group="ADVANCED SETTINGS" value="vice_crop" description="Crops the borders to show or hide border graphics.">
+        <choice name="DISABLED" value="disabled"/>
+        <choice name="SMALL" value="small"/>
+        <choice name="MEDIUM" value="medium"/>
+        <choice name="MAXIMUM" value="maximum"/>
       </feature>
-      <feature submenu="VISUAL RENDERING" name="ZOOM MODE" group="ADVANCED SETTINGS" value="vice_zoom_mode">
-        <choice name="Disabled" value="disabled"/>
-        <choice name="Small" value="small"/>
-        <choice name="Medium" value="medium"/>
-        <choice name="Maximum" value="maximum"/>
-      </feature>
-      <feature submenu="VISUAL RENDERING" name="ZOOM MODE CROP" group="ADVANCED SETTINGS" value="vice_zoom_mode_crop">
+      <feature submenu="VISUAL RENDERING" name="CROP MODE" group="ADVANCED SETTINGS" value="vice_crop_mode">
         <choice name="Horizontal + Vertical" value="both"/>
         <choice name="Horizontal" value="horizontal"/>
         <choice name="Vertical" value="vertical"/>
@@ -2520,12 +2505,134 @@
         <choice name="4:3" value="4:3"/>
         <choice name="5:4" value="5:4"/>
       </feature>
+      <feature submenu="VISUAL RENDERING" name="COLOR PALETTE" group="ADVANCED SETTINGS" value="vice_external_palette" description="Choose which color palette is going to be used.">
+        <choice name="Internal" value="default"/>
+        <choice name="Colodore" value="colodore"/>
+        <choice name="Pepto (PAL)" value="pepto-pal"/>
+        <choice name="Pepto (NTSC)" value="pepto-ntsc"/>
+        <choice name="Pepto (NTSC, Sony)" value="pepto-ntsc-sony"/>
+        <choice name="Christopher Jam" value="cjam"/>
+        <choice name="C64HQ" value="c64hq"/>
+        <choice name="C64S" value="c64s"/>
+        <choice name="CCS64" value="ccs64"/>
+        <choice name="VICE" value="vice"/>
+      </feature>
+      <feature submenu="VISUAL RENDERING" name="COLOR DEPTH" group="ADVANCED SETTINGS" value="vice_gfx_colors">
+        <choice name="Thousands (16-bit)" value="16bit"/>
+        <choice name="Millions (24-bit)" value="24bit"/>
+      </feature>
       <feature submenu="CONTROLS" name="RETROPAD FACE BUTTON OPTIONS" group="ADVANCED SETTINGS" value="vice_retropad_options" description="Select face buttons layout.">
-        <choice name="B=FIRE" value="disabled"/>
+        <choice name="B=Fire/A=Fire2" value="disabled"/>
         <choice name="B=Fire/A=Up" value="jump"/>
-        <choice name="Y=FIRE" value="rotate"/>
+        <choice name="Y=FIRE/B=Fire2" value="rotate"/>
         <choice name="Y=Fire/B=Up" value="rotate_jump"/>
-      </feature> 
+      </feature>
+    </core>
+    <core name="vice_xvic">
+      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
+      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
+      <feature submenu="EMULATION" name="MODEL TYPE" group="ADVANCED SETTINGS" value="vic20_model" description="Define system region (PAL vs NTSC).">
+        <choice name="VIC-20 PAL Auto" value="VIC20 PAL auto"/>
+        <choice name="VIC-20 NTSC Auto" value="VIC20 NTSC auto"/>
+        <choice name="VIC-20 PAL" value="VIC20 PAL"/>
+        <choice name="VIC-20 NTSC" value="VIC20 NTSC"/>
+        <choice name="Super VIC NTSC" value="VIC21"/>
+      </feature>
+      <feature submenu="EMULATION" name="MEMORY EXPANSION" group="ADVANCED SETTINGS" value="vic20_memexpansion">
+        <choice name="NONE" value="Disabled"/>
+        <choice name="3kB" value="3kB"/>
+        <choice name="8kB" value="8kB"/>
+        <choice name="16kB" value="16kB"/>
+        <choice name="24kB" value="24kB"/>
+        <choice name="35kB" value="35kB"/>
+      </feature>
+      <feature submenu="VISUAL RENDERING" name="PIXEL ASPECT RATIO" group="ADVANCED SETTINGS" value="vice_aspect_ratio">
+        <choice name="Automatic" value="auto"/>
+        <choice name="PAL" value="pal"/>
+        <choice name="NTSC" value="ntsc"/>
+        <choice name="1:1" value="raw"/>
+      </feature>
+      <feature submenu="VISUAL RENDERING" name="CROP" group="ADVANCED SETTINGS" value="vice_crop" description="Crops the borders to show or hide border graphics.">
+        <choice name="DISABLED" value="disabled"/>
+        <choice name="SMALL" value="small"/>
+        <choice name="MEDIUM" value="medium"/>
+        <choice name="MAXIMUM" value="maximum"/>
+      </feature>
+      <feature submenu="VISUAL RENDERING" name="CROP MODE" group="ADVANCED SETTINGS" value="vice_crop_mode">
+        <choice name="Horizontal + Vertical" value="both"/>
+        <choice name="Horizontal" value="horizontal"/>
+        <choice name="Vertical" value="vertical"/>
+        <choice name="16:9" value="16:9"/>
+        <choice name="16:10" value="16:10"/>
+        <choice name="4:3" value="4:3"/>
+        <choice name="5:4" value="5:4"/>
+      </feature>
+      <feature submenu="VISUAL RENDERING" name="COLOR PALETTE" group="ADVANCED SETTINGS" value="vic20_palette" description="Choose which color palette is going to be used.">
+        <choice name="Internal" value="default"/>
+        <choice name="Colodore" value="colodore_vic"/>
+        <choice name="Mike (PAL)" value="mike-pal"/>
+        <choice name="Mike (NTSC)" value="mike-ntsc"/>
+        <choice name="VICE" value="vice"/>
+      </feature>
+      <feature submenu="VISUAL RENDERING" name="COLOR DEPTH" group="ADVANCED SETTINGS" value="vice_gfx_colors">
+        <choice name="Thousands (16-bit)" value="16bit"/>
+        <choice name="Millions (24-bit)" value="24bit"/>
+      </feature>
+      <feature submenu="CONTROLS" name="RETROPAD FACE BUTTON OPTIONS" group="ADVANCED SETTINGS" value="vice_retropad_options" description="Select face buttons layout.">
+        <choice name="B=Fire/A=Fire2" value="disabled"/>
+        <choice name="B=Fire/A=Up" value="jump"/>
+        <choice name="Y=FIRE/B=Fire2" value="rotate"/>
+        <choice name="Y=Fire/B=Up" value="rotate_jump"/>
+      </feature>
+    </core>
+    <core name="vice_xplus4">
+      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
+      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
+      <feature submenu="EMULATION" name="MODEL TYPE" group="ADVANCED SETTINGS" value="vice_plus4_model" description="Define system model and region (PAL vs NTSC).">
+        <choice name="C16 PAL" value="C16 PAL"/>
+        <choice name="C16 NTSC" value="C16 NTSC"/>
+        <choice name="PLUS4 PAL" value="PLUS4 PAL"/>
+        <choice name="PLUS4 NTSC" value="PLUS4 NTSC"/>
+        <choice name="V364 NTSC" value="V364 NTSC"/>
+        <choice name="C232 NTSC" value="232 NTSC"/>
+      </feature>
+      <feature submenu="VISUAL RENDERING" name="PIXEL ASPECT RATIO" group="ADVANCED SETTINGS" value="vice_aspect_ratio">
+        <choice name="Automatic" value="auto"/>
+        <choice name="PAL" value="pal"/>
+        <choice name="NTSC" value="ntsc"/>
+        <choice name="1:1" value="raw"/>
+      </feature>
+      <feature submenu="VISUAL RENDERING" name="CROP" group="ADVANCED SETTINGS" value="vice_crop" description="Crops the borders to show or hide border graphics.">
+        <choice name="DISABLED" value="disabled"/>
+        <choice name="SMALL" value="small"/>
+        <choice name="MEDIUM" value="medium"/>
+        <choice name="MAXIMUM" value="maximum"/>
+      </feature>
+      <feature submenu="VISUAL RENDERING" name="CROP MODE" group="ADVANCED SETTINGS" value="vice_crop_mode">
+        <choice name="Horizontal + Vertical" value="both"/>
+        <choice name="Horizontal" value="horizontal"/>
+        <choice name="Vertical" value="vertical"/>
+        <choice name="16:9" value="16:9"/>
+        <choice name="16:10" value="16:10"/>
+        <choice name="4:3" value="4:3"/>
+        <choice name="5:4" value="5:4"/>
+      </feature>
+      <feature submenu="VISUAL RENDERING" name="COLOR PALETTE" group="ADVANCED SETTINGS" value="vice_plus4_external_palette" description="Choose which color palette is going to be used.">
+        <choice name="Internal" value="default"/>
+        <choice name="Colodore" value="colodore_ted"/>
+        <choice name="Yape (PAL)" value="yape-pal"/>
+        <choice name="Yape (NTSC)" value="yape-ntsc"/>
+      </feature>
+      <feature submenu="VISUAL RENDERING" name="COLOR DEPTH" group="ADVANCED SETTINGS" value="vice_gfx_colors">
+        <choice name="Thousands (16-bit)" value="16bit"/>
+        <choice name="Millions (24-bit)" value="24bit"/>
+      </feature>
+      <feature submenu="CONTROLS" name="RETROPAD FACE BUTTON OPTIONS" group="ADVANCED SETTINGS" value="vice_retropad_options" description="Select face buttons layout.">
+        <choice name="B=Fire/A=Fire2" value="disabled"/>
+        <choice name="B=Fire/A=Up" value="jump"/>
+        <choice name="Y=FIRE/B=Fire2" value="rotate"/>
+        <choice name="Y=Fire/B=Up" value="rotate_jump"/>
+      </feature>
     </core>
     <core name="81" features="netplay">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
@@ -5085,6 +5192,10 @@
       <choice name="SDL2" value="SDL2"/>
       <choice name="OPENAL" value="OpenAl"/>
       <choice name="SOUNDIO" value="SoundIo"/>
+    </feature>
+    <feature submenu="CONTROLS" name="INVERT A/B AND X/Y" group="ADVANCED SETTINGS" value="ryujinx_gamepadbuttons" description="Invert A/B and X/Y buttons on Xbox controllers.">
+      <choice name="NO" value="0"/>
+      <choice name="YES" value="1"/>
     </feature>
     <feature submenu="CONTROLS" name="RUMBLE" group="ADVANCED SETTINGS" value="ryujinx_enable_rumble" description="Enable controller's rumble effects.">
       <choice name="NO" value="false"/>

--- a/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
+++ b/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
@@ -329,8 +329,7 @@ namespace emulatorLauncher.libRetro
             ConfigureFbalphaCPS3(retroarchConfig, coreSettings, system, core);
             ConfigureMednafenPce(retroarchConfig, coreSettings, system, core);
             ConfigureNeocd(retroarchConfig, coreSettings, system, core);
-            Configurevicex64(retroarchConfig, coreSettings, system, core);
-            Configurevicexvic(retroarchConfig, coreSettings, system, core);
+            Configurevice(retroarchConfig, coreSettings, system, core);
             ConfigureSwanStation(retroarchConfig, coreSettings, system, core);
             ConfigureFuse(retroarchConfig, coreSettings, system, core);
             ConfigureScummVM(retroarchConfig, coreSettings, system, core);
@@ -2065,29 +2064,41 @@ namespace emulatorLauncher.libRetro
             SetupLightGuns(retroarchConfig, "260");
         }
 
-        private void Configurevicex64(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
+        private void Configurevice(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
         {
-            if (core != "vice_x64")
+            if (core != "vice_x64" && core != "vice_xvic" && core != "vice_xplus4")
                 return;
 
-            BindFeature(coreSettings, "vice_c64_model", "c64_model", "C64 PAL auto");
-            BindFeature(coreSettings, "vice_crop", "crop", "disabled");
+            // Common Vice features
             BindFeature(coreSettings, "vice_warp_boost", "warp_boost", "enabled");
-        }
-
-        private void Configurevicexvic(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
-        {
-            if (core != "vice_xvic")
-                return;
-
-            BindFeature(coreSettings, "vice_vic20_model", "vic20_model", "VIC20 PAL auto");
-            BindFeature(coreSettings, "vice_vic20_memory_expansions", "vic20_memexpansion", "none");
-            BindFeature(coreSettings, "vice_aspect_ratio", "vice_aspect_ratio", "auto");
-            BindFeature(coreSettings, "vice_zoom_mode", "vice_zoom_mode", "disabled");
-            BindFeature(coreSettings, "vice_zoom_mode_crop", "vice_zoom_mode_crop", "both");
+            BindFeature(coreSettings, "vice_aspect_ratio", "vice_aspect_ratio", "auto"); 
+            BindFeature(coreSettings, "vice_crop", "vice_crop", "disabled");
+            BindFeature(coreSettings, "vice_crop_mode", "vice_crop_mode", "both");
             BindFeature(coreSettings, "vice_gfx_colors", "vice_gfx_colors", "16bit");
-            BindFeature(coreSettings, "vice_vic20_external_palette", "vic20_palette", "colodore_vic");
             BindFeature(coreSettings, "vice_retropad_options", "vice_retropad_options", "disabled");
+
+            // vice_x64 specific features
+            if (core == "vice_x64")
+            {
+                BindFeature(coreSettings, "vice_c64_model", "c64_model", "C64 PAL auto");
+                BindFeature(coreSettings, "vice_ram_expansion_unit", "vice_ram_expansion_unit", "none");
+                BindFeature(coreSettings, "vice_external_palette", "vice_external_palette", "colodore");
+            }
+
+            // vice_xvic specific features
+            else if (core == "vice_xvic")
+            {
+                BindFeature(coreSettings, "vice_vic20_model", "vic20_model", "VIC20 PAL auto");
+                BindFeature(coreSettings, "vice_vic20_memory_expansions", "vic20_memexpansion", "none");
+                BindFeature(coreSettings, "vice_vic20_external_palette", "vic20_palette", "colodore_vic");
+            }
+
+            // vice_xplus4 specific features
+            else if (core == "vice_xplus4")
+            {
+                BindFeature(coreSettings, "vice_plus4_model", "vice_plus4_model", "PLUS4 PAL");
+                BindFeature(coreSettings, "vice_plus4_external_palette", "vice_plus4_external_palette", "colodore_ted");
+            }
         }
 
         private void ConfigureSwanStation(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)

--- a/emulatorLauncher/Generators/Ryujinx.Controllers.cs
+++ b/emulatorLauncher/Generators/Ryujinx.Controllers.cs
@@ -225,10 +225,23 @@ namespace emulatorLauncher
             right_joycon["button_zr"] = GetInputKeyName(c, InputKey.r2, tech);
             right_joycon["button_sl"] = "Unbound";
             right_joycon["button_sr"] = "Unbound";
-            right_joycon["button_x"] = GetInputKeyName(c, InputKey.x, tech);
-            right_joycon["button_b"] = GetInputKeyName(c, InputKey.b, tech);
-            right_joycon["button_y"] = GetInputKeyName(c, InputKey.y, tech);
-            right_joycon["button_a"] = GetInputKeyName(c, InputKey.a, tech);
+
+            // Invert button positions for XBOX controllers
+            if (c.IsXInputDevice && Program.SystemConfig.isOptSet("ryujinx_gamepadbuttons") && Program.SystemConfig.getOptBoolean("ryujinx_gamepadbuttons"))
+            {
+                right_joycon["button_x"] = GetInputKeyName(c, InputKey.y, tech);
+                right_joycon["button_b"] = GetInputKeyName(c, InputKey.a, tech);
+                right_joycon["button_y"] = GetInputKeyName(c, InputKey.x, tech);
+                right_joycon["button_a"] = GetInputKeyName(c, InputKey.b, tech);
+            }
+            else
+            {
+                right_joycon["button_x"] = GetInputKeyName(c, InputKey.x, tech);
+                right_joycon["button_b"] = GetInputKeyName(c, InputKey.b, tech);
+                right_joycon["button_y"] = GetInputKeyName(c, InputKey.y, tech);
+                right_joycon["button_a"] = GetInputKeyName(c, InputKey.a, tech);
+            }
+            
             input_config.SetObject("right_joycon", right_joycon);
 
             //player identification part


### PR DESCRIPTION
Vice features (common to the 3 cores): warp boost, aspect ratio, crop, crop mode, gfx color depth, retropad options)
Vice per core:
- - model
- - ram extension
- - palette

Ryujinx:
Add Feature to revert ABXY for XBOX controllers so that button matches name of button instead of position