### PR TITLE
Finalization of vice cores features

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -2437,25 +2437,101 @@
     <core name="vice_x128">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
-    </core>
-    <core name="vice_x64sc">
-      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
-      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
-    </core>
-    <core name="vice_xpet">
-      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
-      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
-    </core>
-    <core name="vice_x64">
-      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
-      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
+	  <feature submenu="EMULATION" name="MODEL TYPE" group="ADVANCED SETTINGS" value="vice_c128_model" description="Define model type and region.">
+        <choice name="C128 PAL" value="C128 PAL"/>
+        <choice name="C128 NTSC" value="C128 NTSC"/>
+        <choice name="C128 D PAL" value="C128 D PAL"/>
+        <choice name="C128 D NTSC" value="C128 D NTSC"/>
+        <choice name="C128 DCR PAL" value="C128 DCR PAL"/>
+        <choice name="C128 DCR NTSC" value="C128 DCR NTSC"/>
+      </feature>
+      <feature submenu="EMULATION" name="MEMORY EXPANSION" group="ADVANCED SETTINGS" value="vice_c128_ram_expansion_unit">
+        <choice name="NONE" value="none"/>
+        <choice name="128kB" value="128kB"/>
+        <choice name="256kB" value="256kB"/>
+        <choice name="512kB" value="512kB"/>
+        <choice name="1024kB" value="1024kB"/>
+        <choice name="2048kB" value="2048kB"/>
+        <choice name="4096kB" value="4096kB"/>
+        <choice name="8192kB" value="8192kB"/>
+        <choice name="16384kB" value="16384kB"/>
+      </feature>
+	  <feature submenu="EMULATION" name="WARP BOOST" group="ADVANCED SETTINGS" value="warp_boost" description="Make warp mode much faster by changing SID emulation to 'FastSID' while warping.">
+        <choice name="ENABLED" value="enabled"/>
+        <choice name="DISABLED" value="disabled"/>
+      </feature>
+	  <feature submenu="VISUAL RENDERING" name="PIXEL ASPECT RATIO" group="ADVANCED SETTINGS" value="vice_aspect_ratio">
+        <choice name="Automatic" value="auto"/>
+        <choice name="PAL" value="pal"/>
+        <choice name="NTSC" value="ntsc"/>
+        <choice name="1:1" value="raw"/>
+      </feature>
       <feature submenu="VISUAL RENDERING" name="CROP" group="ADVANCED SETTINGS" value="vice_crop" description="Crops the borders to show or hide border graphics.">
         <choice name="DISABLED" value="disabled"/>
         <choice name="SMALL" value="small"/>
         <choice name="MEDIUM" value="medium"/>
         <choice name="MAXIMUM" value="maximum"/>
       </feature>
-      <feature submenu="EMULATION" name="MODEL TYPE" group="ADVANCED SETTINGS" value="c64_model" description="Define system region (PAL vs NTSC).">
+      <feature submenu="VISUAL RENDERING" name="CROP MODE" group="ADVANCED SETTINGS" value="vice_crop_mode">
+        <choice name="Horizontal + Vertical" value="both"/>
+        <choice name="Horizontal" value="horizontal"/>
+        <choice name="Vertical" value="vertical"/>
+        <choice name="16:9" value="16:9"/>
+        <choice name="16:10" value="16:10"/>
+        <choice name="4:3" value="4:3"/>
+        <choice name="5:4" value="5:4"/>
+      </feature>
+	  <feature submenu="VISUAL RENDERING" name="COLOR PALETTE" group="ADVANCED SETTINGS" value="vice_external_palette" description="Choose which color palette is going to be used.">
+        <choice name="Internal" value="default"/>
+        <choice name="Colodore" value="colodore"/>
+        <choice name="Pepto (PAL)" value="pepto-pal"/>
+        <choice name="Pepto (NTSC)" value="pepto-ntsc"/>
+        <choice name="Pepto (NTSC, Sony)" value="pepto-ntsc-sony"/>
+        <choice name="Christopher Jam" value="cjam"/>
+        <choice name="C64HQ" value="c64hq"/>
+        <choice name="C64S" value="c64s"/>
+        <choice name="CCS64" value="ccs64"/>
+        <choice name="VICE" value="vice"/>
+      </feature>
+      <feature submenu="VISUAL RENDERING" name="COLOR DEPTH" group="ADVANCED SETTINGS" value="vice_gfx_colors">
+        <choice name="Thousands (16-bit)" value="16bit"/>
+        <choice name="Millions (24-bit)" value="24bit"/>
+      </feature>
+      <feature submenu="CONTROLS" name="RETROPAD FACE BUTTON OPTIONS" group="ADVANCED SETTINGS" value="vice_retropad_options" description="Select face buttons layout.">
+        <choice name="B=Fire/A=Fire2" value="disabled"/>
+        <choice name="B=Fire/A=Up" value="jump"/>
+        <choice name="Y=FIRE/B=Fire2" value="rotate"/>
+        <choice name="Y=Fire/B=Up" value="rotate_jump"/>
+      </feature>
+    </core>
+    <core name="vice_xpet">
+      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
+      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
+	  <feature submenu="EMULATION" name="MODEL TYPE" group="ADVANCED SETTINGS" value="vice_pet_model" description="Define PET computer model.">
+        <choice name="PET 8032" value="8032"/>
+        <choice name="PET 2001" value="2001"/>
+        <choice name="PET 3008" value="3008"/>
+        <choice name="PET 3016" value="3016"/>
+        <choice name="PET 3032" value="3032"/>
+        <choice name="PET 3032B" value="3032B"/>
+        <choice name="PET 4016" value="4016"/>
+        <choice name="PET 4032" value="4032"/>
+        <choice name="PET 4032B" value="4032B"/>
+        <choice name="PET 8096" value="8096"/>
+        <choice name="PET 8296" value="8296"/>
+        <choice name="SUPER PET" value="SUPERPET"/>
+      </feature>
+	  <feature submenu="VISUAL RENDERING" name="COLOR PALETTE" group="ADVANCED SETTINGS" value="vice_pet_external_palette" description="Choose which color palette is going to be used.">
+        <choice name="Internal" value="default"/>
+        <choice name="Green" value="green"/>
+        <choice name="Amber" value="amber"/>
+        <choice name="White" value="white"/>
+      </feature>
+    </core>
+    <core name="vice_x64, vice_x64sc">
+      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
+      <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
+      <feature submenu="EMULATION" name="MODEL TYPE" group="ADVANCED SETTINGS" value="c64_model" description="Define model type and region.">
         <choice name="C64 PAL auto" value="C64 PAL auto"/>
         <choice name="C64 NTSC auto" value="C64 NTSC auto"/>
         <choice name="C64C PAL auto" value="C64C PAL auto"/>
@@ -2531,7 +2607,7 @@
     <core name="vice_xvic">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
-      <feature submenu="EMULATION" name="MODEL TYPE" group="ADVANCED SETTINGS" value="vic20_model" description="Define system region (PAL vs NTSC).">
+      <feature submenu="EMULATION" name="MODEL TYPE" group="ADVANCED SETTINGS" value="vic20_model" description="Define model type and region.">
         <choice name="VIC-20 PAL Auto" value="VIC20 PAL auto"/>
         <choice name="VIC-20 NTSC Auto" value="VIC20 NTSC auto"/>
         <choice name="VIC-20 PAL" value="VIC20 PAL"/>
@@ -2588,7 +2664,7 @@
     <core name="vice_xplus4">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
-      <feature submenu="EMULATION" name="MODEL TYPE" group="ADVANCED SETTINGS" value="vice_plus4_model" description="Define system model and region (PAL vs NTSC).">
+      <feature submenu="EMULATION" name="MODEL TYPE" group="ADVANCED SETTINGS" value="vice_plus4_model" description="Define model type and region.">
         <choice name="C16 PAL" value="C16 PAL"/>
         <choice name="C16 NTSC" value="C16 NTSC"/>
         <choice name="PLUS4 PAL" value="PLUS4 PAL"/>

--- a/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
+++ b/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
@@ -2066,7 +2066,7 @@ namespace emulatorLauncher.libRetro
 
         private void Configurevice(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
         {
-            if (core != "vice_x64" && core != "vice_xvic" && core != "vice_xplus4")
+            if (core != "vice_x64" && core != "vice_xvic" && core != "vice_xplus4" && core != "vice_x128" && core != "vice_x64sc" && core != "vice_xpet")
                 return;
 
             // Common Vice features
@@ -2078,7 +2078,7 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "vice_retropad_options", "vice_retropad_options", "disabled");
 
             // vice_x64 specific features
-            if (core == "vice_x64")
+            if (core == "vice_x64" || core == "vice_x64sc")
             {
                 BindFeature(coreSettings, "vice_c64_model", "c64_model", "C64 PAL auto");
                 BindFeature(coreSettings, "vice_ram_expansion_unit", "vice_ram_expansion_unit", "none");
@@ -2098,6 +2098,21 @@ namespace emulatorLauncher.libRetro
             {
                 BindFeature(coreSettings, "vice_plus4_model", "vice_plus4_model", "PLUS4 PAL");
                 BindFeature(coreSettings, "vice_plus4_external_palette", "vice_plus4_external_palette", "colodore_ted");
+            }
+
+            // vice_x128 specific features
+            else if (core == "vice_x128")
+            {
+                BindFeature(coreSettings, "vice_c128_model", "vice_c128_model", "C128 PAL");
+                BindFeature(coreSettings, "vice_c128_ram_expansion_unit", "vice_c128_ram_expansion_unit", "none");
+                BindFeature(coreSettings, "vice_external_palette", "vice_external_palette", "colodore");
+            }
+
+            // vice_xpet specific features
+            else if (core == "vice_xpet")
+            {
+                BindFeature(coreSettings, "vice_pet_model", "vice_pet_model", "8032");
+                BindFeature(coreSettings, "vice_pet_external_palette", "vice_pet_external_palette", "default");
             }
         }
 
@@ -2125,13 +2140,13 @@ namespace emulatorLauncher.libRetro
             if (SystemConfig.isOptSet("zx_controller1") && !string.IsNullOrEmpty(SystemConfig["zx_controller1"]))
                 retroarchConfig["input_libretro_device_p1"] = SystemConfig["zx_controller1"];
             else if (Features.IsSupported("zx_controller1"))
-                retroarchConfig["input_libretro_device_p1"] = "769";
+                retroarchConfig["input_libretro_device_p1"] = "513";
 
             //player 2 controller - sinclair 2 as default
             if (SystemConfig.isOptSet("zx_controller2") && !string.IsNullOrEmpty(SystemConfig["zx_controller2"]))
                 retroarchConfig["input_libretro_device_p2"] = SystemConfig["zx_controller2"];
             else if (Features.IsSupported("zx_controller2"))
-                retroarchConfig["input_libretro_device_p2"] = "1025";
+                retroarchConfig["input_libretro_device_p2"] = "513";
 
             //if using keyboard only option, disable controllers and use keyboard as device_p3 as stated in libretro core documentation
             //3 options : keyboard only (disables joysticks), joysticks only (disables keyboard) or keyboard + joysticks (add keyboard as p3)


### PR DESCRIPTION
Added vice_xpet and vice_x128 features.
Added vice_x64sc features (same as vice_x64).

Fuse : switch default controller type to Kempton instead of Sinclair1, as it was before, it was more common joystick type and works in more games.