### PR TITLE
Yuzu features injection fix (\default issue)

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -5629,15 +5629,22 @@
   <!-- YUZU -->
   <emulator name="yuzu, yuzu-early-access">
     <sharedFeature group="GENERAL SETTINGS" value="disableautocontrollers"/>
+	<feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="use_vsync">
+      <choice name="YES" value="true"/>
+      <choice name="NO" value="false"/>
+    </feature>
     <feature name="INTERNAL RESOLUTION" group="GENERAL SETTINGS" value="resolution_setup" description="Improve fidelity of 3D models at the cost of increased performance requirements.">
       <choice name="0.5x (360p/540p)" value="0"/>
       <choice name="0.75x (540p/810p)" value="1"/>
       <choice name="1x (720p/1080p)" value="2"/>
-      <choice name="2x (1440p/2160p)" value="3"/>
-      <choice name="3x (2160p/3240p)" value="4"/>
-      <choice name="4x (2880p/4320p)" value="5"/>
-      <choice name="5x (3600p/5400p)" value="6"/>
-      <choice name="6x (4320p/6480p)" value="7"/>
+	  <choice name="1.5x (1080p/1620p)" value="3"/>
+      <choice name="2x (1440p/2160p)" value="4"/>
+      <choice name="3x (2160p/3240p)" value="5"/>
+      <choice name="4x (2880p/4320p)" value="6"/>
+      <choice name="5x (3600p/5400p)" value="7"/>
+      <choice name="6x (4320p/6480p)" value="8"/>
+	  <choice name="7x (5040p/7560p)" value="9"/>
+      <choice name="8x (5760p/8640p)" value="10"/>
     </feature>
 	<feature submenu="EMULATION" name="REGION" group="ADVANCED SETTINGS" value="yuzu_region_value" description="Force the region of the system.">
       <choice name="JAPAN" value="0"/>
@@ -5657,6 +5664,7 @@
     <feature submenu="VISUAL RENDERING" name="ANTI ALIASING" group="ADVANCED SETTINGS" value="anti_aliasing" description="Set Anti Aliasing for rendered content.">
       <choice name="NONE" value="0"/>
       <choice name="FXAA" value="1"/>
+	  <choice name="MSAA" value="2"/>
     </feature>
     <feature submenu="VISUAL RENDERING" name="SCALING FILTER" group="ADVANCED SETTINGS" value="scaling_filter" description="Set scaling filter for rendered content.">
       <choice name="Nearest Neighbor" value="0"/>
@@ -5666,9 +5674,18 @@
       <choice name="ScaleForce" value="4"/>
       <choice name="AMD's FidelityFX Super Resolution" value="5"/>
     </feature>
+	<feature submenu="AUDIO" name="AUDIO OUTPUT" group="ADVANCED SETTINGS" value="sound_index">
+      <choice name="STEREO" value="1"/>
+      <choice name="SURROUND" value="2"/>
+	  <choice name="MONO" value="0"/>
+    </feature>
     <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="backend">
       <choice name="OPENGL" value="0"/>
       <choice name="VULKAN" value="1"/>
+    </feature>
+	<feature submenu="DRIVERS" name="AUDIO" group="ADVANCED SETTINGS" value="audio_backend">
+      <choice name="CUBEB" value="cubeb"/>
+      <choice name="SDL2" value="sdl2"/>
     </feature>
     <feature submenu="CONTROLS" name="PLAYER 1 CONTROLLER TYPE" group="ADVANCED SETTINGS" value="player_0_type" description="Sets the player controller type">
       <choice name="PRO CONTROLLER" value="0"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -5629,7 +5629,7 @@
   <!-- YUZU -->
   <emulator name="yuzu, yuzu-early-access">
     <sharedFeature group="GENERAL SETTINGS" value="disableautocontrollers"/>
-	<feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="use_vsync">
+    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="use_vsync">
       <choice name="YES" value="true"/>
       <choice name="NO" value="false"/>
     </feature>
@@ -5637,13 +5637,13 @@
       <choice name="0.5x (360p/540p)" value="0"/>
       <choice name="0.75x (540p/810p)" value="1"/>
       <choice name="1x (720p/1080p)" value="2"/>
-	  <choice name="1.5x (1080p/1620p)" value="3"/>
+      <choice name="1.5x (1080p/1620p)" value="3"/>
       <choice name="2x (1440p/2160p)" value="4"/>
       <choice name="3x (2160p/3240p)" value="5"/>
       <choice name="4x (2880p/4320p)" value="6"/>
       <choice name="5x (3600p/5400p)" value="7"/>
       <choice name="6x (4320p/6480p)" value="8"/>
-	  <choice name="7x (5040p/7560p)" value="9"/>
+      <choice name="7x (5040p/7560p)" value="9"/>
       <choice name="8x (5760p/8640p)" value="10"/>
     </feature>
 	<feature submenu="EMULATION" name="REGION" group="ADVANCED SETTINGS" value="yuzu_region_value" description="Force the region of the system.">
@@ -5664,7 +5664,7 @@
     <feature submenu="VISUAL RENDERING" name="ANTI ALIASING" group="ADVANCED SETTINGS" value="anti_aliasing" description="Set Anti Aliasing for rendered content.">
       <choice name="NONE" value="0"/>
       <choice name="FXAA" value="1"/>
-	  <choice name="MSAA" value="2"/>
+      <choice name="MSAA" value="2"/>
     </feature>
     <feature submenu="VISUAL RENDERING" name="SCALING FILTER" group="ADVANCED SETTINGS" value="scaling_filter" description="Set scaling filter for rendered content.">
       <choice name="Nearest Neighbor" value="0"/>
@@ -5674,16 +5674,16 @@
       <choice name="ScaleForce" value="4"/>
       <choice name="AMD's FidelityFX Super Resolution" value="5"/>
     </feature>
-	<feature submenu="AUDIO" name="AUDIO OUTPUT" group="ADVANCED SETTINGS" value="sound_index">
+    <feature submenu="AUDIO" name="AUDIO OUTPUT" group="ADVANCED SETTINGS" value="sound_index">
       <choice name="STEREO" value="1"/>
       <choice name="SURROUND" value="2"/>
-	  <choice name="MONO" value="0"/>
+      <choice name="MONO" value="0"/>
     </feature>
     <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="backend">
       <choice name="OPENGL" value="0"/>
       <choice name="VULKAN" value="1"/>
     </feature>
-	<feature submenu="DRIVERS" name="AUDIO" group="ADVANCED SETTINGS" value="audio_backend">
+    <feature submenu="DRIVERS" name="AUDIO" group="ADVANCED SETTINGS" value="audio_backend">
       <choice name="CUBEB" value="cubeb"/>
       <choice name="SDL2" value="sdl2"/>
     </feature>

--- a/emulatorLauncher/Generators/Cemu.Generator.cs
+++ b/emulatorLauncher/Generators/Cemu.Generator.cs
@@ -113,6 +113,7 @@ namespace emulatorLauncher
 
             var xdoc = File.Exists(settingsFile) ? XElement.Load(settingsFile) : new XElement("content");
 
+            xdoc.SetElementValue("check_update", "false");
             BindFeature(xdoc, "console_language", "wiiu_language", GetDefaultWiiULanguage());
 
             // Graphic part of settings file

--- a/emulatorLauncher/Generators/Yuzu.Generator.cs
+++ b/emulatorLauncher/Generators/Yuzu.Generator.cs
@@ -130,65 +130,60 @@ namespace emulatorLauncher
                     ini.WriteValue("UI", "Screenshots\\screenshot_path", screenshotpath);
                 }
 
-                // backend
-                if (SystemConfig.isOptSet("backend") && !string.IsNullOrEmpty(SystemConfig["backend"]) && SystemConfig["backend"] != "0")
-                {
-                    ini.WriteValue("Renderer", "backend\\default", "false");
+                // Audio output
+                ini.WriteValue("System", "sound_index\\default", "false");
+                if (SystemConfig.isOptSet("sound_index") && !string.IsNullOrEmpty(SystemConfig["sound_index"]))
+                    ini.WriteValue("System", "sound_index", SystemConfig["sound_index"]);
+                else if (Features.IsSupported("sound_index"))
+                    ini.WriteValue("System", "sound_index", "1");
+
+                // Video and Audio drivers
+                ini.WriteValue("Renderer", "backend\\default", "false");
+                if (SystemConfig.isOptSet("backend") && !string.IsNullOrEmpty(SystemConfig["backend"]))
                     ini.WriteValue("Renderer", "backend", SystemConfig["backend"]);
-                }
                 else if (Features.IsSupported("backend"))
-                {
-                    ini.WriteValue("Renderer", "backend\\default", "true");
-                    ini.WriteValue("Renderer", "backend", "0");
-                }
+                    ini.WriteValue("Renderer", "backend", "1");
+
+                ini.WriteValue("Audio", "output_engine\\default", "false");
+                if (SystemConfig.isOptSet("audio_backend") && !string.IsNullOrEmpty(SystemConfig["audio_backend"]))
+                    ini.WriteValue("Audio", "output_engine", SystemConfig["audio_backend"]);
+                else if (Features.IsSupported("audio_backend"))
+                    ini.WriteValue("Audio", "output_engine", "auto");
 
                 // resolution_setup
-                if (SystemConfig.isOptSet("resolution_setup") && !string.IsNullOrEmpty(SystemConfig["resolution_setup"]) && SystemConfig["resolution_setup"] != "2")
-                {
-                    ini.WriteValue("Renderer", "resolution_setup\\default", "false");
+                ini.WriteValue("Renderer", "resolution_setup\\default", "false");
+                if (SystemConfig.isOptSet("resolution_setup") && !string.IsNullOrEmpty(SystemConfig["resolution_setup"]))
                     ini.WriteValue("Renderer", "resolution_setup", SystemConfig["resolution_setup"]);
-                }
                 else if (Features.IsSupported("resolution_setup"))
-                {
-                    ini.WriteValue("Renderer", "resolution_setup\\default", "true");
                     ini.WriteValue("Renderer", "resolution_setup", "2");
-                }
+
+                // Vsync
+                ini.WriteValue("Renderer", "use_vsync\\default", "false");
+                if (SystemConfig.isOptSet("use_vsync") && !string.IsNullOrEmpty(SystemConfig["use_vsync"]))
+                    ini.WriteValue("Renderer", "use_vsync", SystemConfig["use_vsync"]);
+                else if (Features.IsSupported("use_vsync"))
+                    ini.WriteValue("Renderer", "use_vsync", "true");
 
                 // anti_aliasing
-                if (SystemConfig.isOptSet("anti_aliasing") && SystemConfig.getOptBoolean("anti_aliasing"))
-                {
-                    ini.WriteValue("Renderer", "anti_aliasing\\default", "false");
-                    ini.WriteValue("Renderer", "anti_aliasing", "1");
-                }
+                ini.WriteValue("Renderer", "anti_aliasing\\default", "false");
+                if (SystemConfig.isOptSet("anti_aliasing") && !string.IsNullOrEmpty(SystemConfig["anti_aliasing"]))
+                    ini.WriteValue("Renderer", "anti_aliasing", SystemConfig["anti_aliasing"]);
                 else if (Features.IsSupported("anti_aliasing"))
-                {
-                    ini.WriteValue("Renderer", "anti_aliasing\\default", "true");
                     ini.WriteValue("Renderer", "anti_aliasing", "0");
-                }
 
                 // scaling_filter
-                if (SystemConfig.isOptSet("scaling_filter") && !string.IsNullOrEmpty(SystemConfig["scaling_filter"]) && SystemConfig["scaling_filter"] != "1")
-                {
-                    ini.WriteValue("Renderer", "scaling_filter\\default", "false");
+                ini.WriteValue("Renderer", "scaling_filter\\default", "false");
+                if (SystemConfig.isOptSet("scaling_filter") && !string.IsNullOrEmpty(SystemConfig["scaling_filter"]))
                     ini.WriteValue("Renderer", "scaling_filter", SystemConfig["scaling_filter"]);
-                }
                 else if (Features.IsSupported("scaling_filter"))
-                {
-                    ini.WriteValue("Renderer", "scaling_filter\\default", "true");
                     ini.WriteValue("Renderer", "scaling_filter", "1");
-                }
 
                 //CPU accuracy (auto except if the user chooses otherwise)
-                if (SystemConfig.isOptSet("cpu_accuracy") && !string.IsNullOrEmpty(SystemConfig["cpu_accuracy"]) && SystemConfig["cpu_accuracy"] != "0")
-                {
-                    ini.WriteValue("Cpu", "cpu_accuracy\\default", "false");
+                ini.WriteValue("Cpu", "cpu_accuracy\\default", "false");
+                if (SystemConfig.isOptSet("cpu_accuracy") && !string.IsNullOrEmpty(SystemConfig["cpu_accuracy"]))
                     ini.WriteValue("Cpu", "cpu_accuracy", SystemConfig["cpu_accuracy"]);
-                }
                 else
-                {
-                    ini.WriteValue("Cpu", "cpu_accuracy\\default", "true");
                     ini.WriteValue("Cpu", "cpu_accuracy", "0");
-                }
             }
         }
 


### PR DESCRIPTION
Fix renderer choice in yuzu and fix default value to false to avoid this case in the future.
Even when default = false, the default value works properly.

Added missing resolutions, MSAA option, vsync feature, audio driver and output.

cemu: force disabling update check 