### PR TITLE
Libretro, rpcs3, dolphin and Teknoparrot

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -1106,9 +1106,17 @@
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
     </core>
     <core name="fbalpha" features="cheevos, netplay">
+      <feature submenu="VIDEO" name="TATE MODE" group="ADVANCED SETTINGS" value="fba_vertical_mode" description="Rotate display for vertical games, to enable for use with mega-bezels.">
+        <choice name="NO" value="disabled"/>
+        <choice name="YES" value="enabled"/>
+      </feature>      
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
     </core>
     <core name="fbalpha2012" features="cheevos, netplay">
+      <feature submenu="VIDEO" name="TATE MODE" group="ADVANCED SETTINGS" value="fba2012_vertical_mode" description="Rotate display for vertical games, to enable for use with mega-bezels.">
+        <choice name="NO" value="disabled"/>
+        <choice name="YES" value="enabled"/>
+      </feature>       
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
     </core>
     <core name="fbalpha2012_neogeo" features="cheevos, netplay">
@@ -1281,6 +1289,10 @@
       <feature submenu="VIDEO" name="WIDESCREEN" group="ADVANCED SETTINGS" value="widescreen_hack" description="Display the emulated framebuffer at a widescreen aspect ratio. Get best results with full 3D games." order="85">
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>
+      </feature>
+      <feature submenu="VIDEO" name="TATE MODE" value="reicast_screen_rotation" group="ADVANCED SETTINGS" description="Rotate display for vertical games, to enable for use with mega-bezels.">
+        <choice name="NO" value="horizontal"/>
+        <choice name="YES" value="vertical"/>
       </feature>
       <feature submenu="VISUAL RENDERING" name="TEXTURES ENHANCEMENT" group="ADVANCED SETTINGS" value="texture_upscaling" description="Enhance hand drawn 2D pixel art graphics.">
         <choice name="NO" value="off"/>
@@ -3040,10 +3052,10 @@
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
     </core>
     <core name="fbneo" features="cheevos, netplay">
-      <!--<feature submenu="VIDEO" name="TATE MODE" value="fbneo-vertical-mode" description="Rotate display for vertical screen.">
+      <feature submenu="VIDEO" name="TATE MODE" group="ADVANCED SETTINGS" value="fbneo-vertical-mode" description="Rotate display for vertical games, to enable for use with mega-bezels.">
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>
-      </feature>-->
+      </feature>
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
       <sharedFeature submenu="CONTROLS" group="ADVANCED SETTINGS" value="use_guns"/>
       <feature submenu="CONTROLS" name="SHOW LIGHTGUN CROSSHAIR" group="ADVANCED SETTINGS" value="fbneo-lightgun-hide-crosshair" description="Display crosshair if a lightgun is used.">

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -6107,6 +6107,10 @@
   <emulator name="teknoparrot">
     <sharedFeature group="GENERAL SETTINGS" value="disableautocontrollers"/>
     <sharedFeature group="ADVANCED SETTINGS" value="videomode"/>
+    <feature submenu="EMULATION" name="DISABLE ADMIN RIGHTS" group="ADVANCED SETTINGS" value="requires_admin">
+      <choice name="NO" value="0"/>
+      <choice name="YES" value="1"/>
+    </feature>
   </emulator>
   <!-- VISUAL PINBALL -->
   <emulator name="vpinball">

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -5794,6 +5794,13 @@
       <choice name="NO" value="false"/>
       <choice name="YES" value="true"/>
     </feature>
+    <feature submenu="VIDEO" name="DRIVER WAKE-UP DELAY" group="ADVANCED SETTINGS" value="driver_wake" description="Change this setting when encountering unstable games. The higher value, the better stability it may provide. 200μs and 400μs are generally good for most games.">
+      <choice name="1μs" value="1"/>
+      <choice name="50μs" value="50"/>
+      <choice name="100μs" value="100"/>
+      <choice name="200μs" value="200"/>
+      <choice name="400μs" value="400"/>
+    </feature>
     <feature submenu="SCREEN SYNC" name="VSYNC" group="ADVANCED SETTINGS" value="vsync" description="By having this off you might obtain a higher frame rate at the cost of tearing artifacts in the game.">
       <choice name="NO" value="false"/>
       <choice name="YES" value="true"/>
@@ -5837,6 +5844,11 @@
       <choice name="STEREO" value="Stereo"/>
       <choice name="SURROUND 5.1" value="Surround 5.1"/>
       <choice name="SURROUND 7.1" value="Surround 7.1"/>
+    </feature>
+    <feature submenu="AUDIO" name="TIME STRETCHING" group="ADVANCED SETTINGS" value="time_stretching" description="Reduces crackle and stutter, but may cause a very noticeable reduction in audio quality on slower CPUs, leave AUTO to disable.">
+      <choice name="LOW" value="low"/>
+      <choice name="MEDIUM" value="medium"/>
+      <choice name="HIGH" value="high"/>
     </feature>
     <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="gfxbackend" description="Choose which graphics API library to use. Vulkan is better, when supported.">
       <choice name="VULKAN" value="Vulkan"/>

--- a/emulatorLauncher/Generators/Dolphin.Controllers.cs
+++ b/emulatorLauncher/Generators/Dolphin.Controllers.cs
@@ -543,6 +543,79 @@ namespace emulatorLauncher
 
                 ini.Save();
             }
+
+            // Reset hotkeys
+            string hotkeyini = Path.Combine(path, "User", "Config", "Hotkeys.ini");
+            if (File.Exists(hotkeyini))
+                ResetHotkeysToDefault(hotkeyini);
+        }
+
+        private static void ResetHotkeysToDefault(string iniFile)
+        {
+            if (Program.Controllers.Count == 0)
+                return;
+
+            using (IniFile ini = new IniFile(iniFile, IniOptions.UseSpaces))
+            {
+                var c1 = Program.Controllers.FirstOrDefault(c => c.PlayerIndex == 1);
+
+                string tech = "XInput";
+                string deviceName = "Gamepad";
+
+                if (c1.Config.Type == "keyboard")
+                {
+                    tech = "DInput";
+                    deviceName = "Keyboard Mouse";
+                }
+                else if (!c1.IsXInputDevice)
+                {
+                    var s = c1.SdlController;
+                    if (s != null)
+                    {
+                        tech = "SDL";
+                        deviceName = s.Name;
+                    }
+                }
+
+                if (tech == "XInput")
+                {
+                    ini.WriteValue("Hotkeys", "Device", tech + "/" + "0" + "/" + deviceName);
+                    ini.WriteValue("Hotkeys", "General/Toggle Pause", "Back&`Button A`");
+                    ini.WriteValue("Hotkeys", "General/Toggle Fullscreen", "Back&`Button B`");
+                    ini.WriteValue("Hotkeys", "General/Exit", "Back&Start");
+                    ini.WriteValue("Hotkeys", "Load State/Load State Slot 1", "Back&`Button X`");
+                    ini.WriteValue("Hotkeys", "Save State/Save State Slot 1", "Back&`Button Y`");
+                    ini.WriteValue("Hotkeys", "General/Take Screenshot", "Back&`Trigger R`");
+                    ini.WriteValue("Hotkeys", "General/Eject Disc", "Back&`Shoulder L`");
+                    ini.WriteValue("Hotkeys", "General/Change Disc", "Back&`Shoulder R`");
+                }
+
+                else if (tech == "SDL")
+                {
+                    ini.WriteValue("Hotkeys", "Device", tech + "/" + "0" + "/" + deviceName);
+                    ini.WriteValue("Hotkeys", "General/Toggle Pause", "`Button 4`&`Button 0`");
+                    ini.WriteValue("Hotkeys", "General/Toggle Fullscreen", "`Button 4`&`Button 1`");
+                    ini.WriteValue("Hotkeys", "General/Exit", "`Button 4`&`Button 6`");
+                    ini.WriteValue("Hotkeys", "Load State/Load State Slot 1", "`Button 4`&`Button 2`");
+                    ini.WriteValue("Hotkeys", "Save State/Save State Slot 1", "`Button 4`&`Button 3`");
+                    ini.WriteValue("Hotkeys", "General/Take Screenshot", "`Button 4`&`Full Axis 5+`");
+                    ini.WriteValue("Hotkeys", "General/Eject Disc", "`Button 4`&`Button 9`");
+                    ini.WriteValue("Hotkeys", "General/Change Disc", "`Button 4`&`Button 10`");
+                }
+
+                else        // Keyboard
+                {
+                    ini.WriteValue("Hotkeys", "Device", "DInput/0/Keyboard Mouse");
+                    ini.WriteValue("Hotkeys", "General/Toggle Pause", "`F10`");
+                    ini.WriteValue("Hotkeys", "General/Toggle Fullscreen", "@(Alt+RETURN)");
+                    ini.WriteValue("Hotkeys", "General/Exit", "ESCAPE");
+                    ini.WriteValue("Hotkeys", "Load State/Load State Slot 1", "`F1`");
+                    ini.WriteValue("Hotkeys", "Save State/Save State Slot 1", "@(Alt+`F1`)");
+                    ini.WriteValue("Hotkeys", "General/Take Screenshot", "`F9`");
+                    ini.WriteValue("Hotkeys", "General/Eject Disc", "@(Alt+E)");
+                    ini.WriteValue("Hotkeys", "General/Change Disc", "@(Alt+S)");
+                }
+            }
         }
 
         private static string ToDolphinKey(long id)

--- a/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
+++ b/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
@@ -315,6 +315,8 @@ namespace emulatorLauncher.libRetro
             ConfigureFbneo(retroarchConfig, coreSettings, system, core);
             ConfigureGambatte(retroarchConfig, coreSettings, system, core);
             ConfigureMame(retroarchConfig, coreSettings, system, core);
+            ConfigureFbalpha(retroarchConfig, coreSettings, system, core);
+            ConfigureFbalpha2012(retroarchConfig, coreSettings, system, core);
             ConfigureFbalphaCPS1(retroarchConfig, coreSettings, system, core);
             ConfigureFbalphaCPS2(retroarchConfig, coreSettings, system, core);
             ConfigureFbalphaCPS3(retroarchConfig, coreSettings, system, core);
@@ -714,6 +716,28 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "pce_adpcmvolume", "pcecdvolume", "100");
             BindFeature(coreSettings, "pce_cddavolume", "pcecdvolume", "100");
             BindFeature(coreSettings, "pce_cdpsgvolume", "pcecdvolume", "100");
+        }
+
+        private void ConfigureFbalpha(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
+        {
+            if (core != "fbalpha")
+                return;
+
+            BindFeature(coreSettings, "fba-vertical-mode", "fba_vertical_mode", "disabled");
+
+            if (SystemConfig["fba_vertical_mode"] == "enabled")
+                SystemConfig["bezel"] = "none";
+        }
+
+        private void ConfigureFbalpha2012(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
+        {
+            if (core != "fbalpha2012")
+                return;
+
+            BindFeature(coreSettings, "fbneo-vertical-mode", "fba2012_vertical_mode", "disabled");
+
+            if (SystemConfig["fba2012_vertical_mode"] == "enabled")
+                SystemConfig["bezel"] = "none";
         }
 
         private void ConfigureFbalphaCPS3(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
@@ -2076,6 +2100,10 @@ namespace emulatorLauncher.libRetro
 
             BindFeature(coreSettings, "reicast_widescreen_hack", "widescreen_hack", "disabled");
             BindFeature(coreSettings, "reicast_widescreen_cheats", "widescreen_hack", "disabled");
+            BindFeature(coreSettings, "reicast_screen_rotation", "reicast_screen_rotation", "horizontal");
+
+            if (SystemConfig["reicast_screen_rotation"] == "vertical")
+                SystemConfig["bezel"] = "none";
 
             if (SystemConfig["widescreen_hack"] == "enabled")
             {

--- a/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
+++ b/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
@@ -1980,6 +1980,7 @@ namespace emulatorLauncher.libRetro
             coreSettings["dosbox_pure_auto_mapping"] = "true";
             coreSettings["dosbox_pure_bind_unused"] = "true";
             coreSettings["dosbox_pure_savestate"] = "on";
+            retroarchConfig["video_font_enable"] = "false"; // Disable OSD for dosbox_pure
 
             BindFeature(coreSettings, "dosbox_pure_aspect_correction", "ratio", "true");
             BindFeature(coreSettings, "dosbox_pure_cga", "cga", "early_auto");

--- a/emulatorLauncher/Generators/LibRetro.Generator.cs
+++ b/emulatorLauncher/Generators/LibRetro.Generator.cs
@@ -230,7 +230,7 @@ namespace emulatorLauncher.libRetro
             BindBoolFeature(retroarchConfig, "video_frame_delay_auto", "video_frame_delay_auto", "true", "false"); // Auto frame delay (input delay reduction via frame timing)
             BindBoolFeature(retroarchConfig, "quit_press_twice", "PressTwice", "true", "false"); // Press hotkeys twice to exit
             
-            BindFeature(retroarchConfig, "video_font_enable", "OnScreenMsg", "false"); // OSD notifications
+            BindFeature(retroarchConfig, "video_font_enable", "OnScreenMsg", "true"); // OSD notifications
             BindFeature(retroarchConfig, "video_rotation", "RotateVideo", "0"); // video rotation
             BindFeature(retroarchConfig, "screen_orientation", "RotateScreen", "0"); // screen orientation
             BindFeature(retroarchConfig, "crt_switch_resolution", "CRTSwitch", "0"); // CRT Switch

--- a/emulatorLauncher/Generators/Rpcs3.Generator.cs
+++ b/emulatorLauncher/Generators/Rpcs3.Generator.cs
@@ -123,7 +123,7 @@ namespace emulatorLauncher
             BindFeature(core, "PPU LLVM Accurate Vector NaN values", "vectornan", "false");
             BindFeature(core, "Full Width AVX-512", "fullavx", "false");
 
-            //xfloat is managed through 3 options now in latest release
+            // xfloat is managed through 3 options now in latest release
             if (SystemConfig.isOptSet("xfloat") && (SystemConfig["xfloat"] == "Accurate"))
             {
                 core["Accurate xfloat"] = "true";
@@ -163,8 +163,9 @@ namespace emulatorLauncher
             BindFeature(video, "Enable 3D", "enable3d", "false");
             BindFeature(video, "Anisotropic Filter Override", "anisotropicfilter", "0");
             BindFeature(video, "Shader Precision", "shader_quality", "Auto");
+            BindFeature(video, "Driver Wake-Up Delay", "driver_wake", "1");
 
-            //ZCULL Accuracy
+            // ZCULL Accuracy
             if (SystemConfig.isOptSet("zcull_accuracy") && (SystemConfig["zcull_accuracy"] == "Approximate"))
             {
                 core["Relaxed ZCULL Sync"] = "false";
@@ -211,6 +212,30 @@ namespace emulatorLauncher
             var audio = yml.GetOrCreateContainer("Audio");
             BindFeature(audio, "Renderer", "audiobackend", "Cubeb");
             BindFeature(audio, "Audio Format", "audiochannels", "Stereo");
+            BindFeature(audio, "Enable Buffering", "audio_buffering", "true");
+            if (SystemConfig.isOptSet("time_stretching") && (SystemConfig["time_stretching"] == "low"))
+            {
+                audio["Enable Buffering"] = "true";
+                audio["Enable time stretching"] = "true";
+                audio["Time Stretching Threshold"] = "25";
+            }
+            else if (SystemConfig.isOptSet("time_stretching") && (SystemConfig["time_stretching"] == "medium"))
+            {
+                audio["Enable Buffering"] = "true";
+                audio["Enable time stretching"] = "true";
+                audio["Time Stretching Threshold"] = "50";
+            }
+            else if (SystemConfig.isOptSet("time_stretching") && (SystemConfig["time_stretching"] == "high"))
+            {
+                audio["Enable Buffering"] = "true";
+                audio["Enable time stretching"] = "true";
+                audio["Time Stretching Threshold"] = "75";
+            }
+            else if (Features.IsSupported("time_stretching"))
+            {
+                audio["Enable time stretching"] = "false";
+                audio["Time Stretching Threshold"] = "75";
+            }
 
             // Handle System part of yml file
             var system_region = yml.GetOrCreateContainer("System");

--- a/emulatorLauncher/Generators/TeknoParrot.generator.cs
+++ b/emulatorLauncher/Generators/TeknoParrot.generator.cs
@@ -230,6 +230,14 @@ namespace emulatorLauncher
                 resolutionHeight.FieldValue = resY.ToString();
             }
 
+            // Option to disable RequiresAdmin tag
+            var requiresadmin = profile.RequiresAdmin;
+            
+            if (SystemConfig.isOptSet("requires_admin") && SystemConfig.getOptBoolean("requires_admin"))
+                userProfile.RequiresAdmin = false;
+            else
+                userProfile.RequiresAdmin = requiresadmin;
+
             ConfigureControllers(userProfile);
 
             JoystickHelper.SerializeGameProfile(userProfile, userProfilePath);


### PR DESCRIPTION
- Reenable OSD messages by default
- Add RPCS3 features (wake-up delay and time stretching)
- Add TATE MODE (vertical screen) for flycast, fbneo, fbalpha and fbalpha2012
- Add option to disable RequiresAdmin in Teknoparrot
- Inject dolphin hotkeys