### PR TITLE
Features cleanup & finalization + extras

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -2211,6 +2211,14 @@
     <core name="mednafen_pce_fast" features="cheevos, netplay">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
+      <feature submenu="CONTROLS" name="CONTROLLER 1 TYPE" group="ADVANCED SETTINGS" value="pce_controller1">
+        <choice name="JOYPAD" value="1"/>
+        <choice name="MOUSE" value="2"/>
+      </feature>
+      <feature submenu="CONTROLS" name="CONTROLLER 2 TYPE" group="ADVANCED SETTINGS" value="pce_controller2">
+        <choice name="JOYPAD" value="1"/>
+        <choice name="MOUSE" value="2"/>
+      </feature>
     </core>
     <core name="mednafen_pce" features="cheevos, netplay">
       <feature submenu="VIDEO" name="OVERSCAN" group="ADVANCED SETTINGS" value="pce_h_overscan" description="Show or crop overscan. 'Auto' will try to adapt to game, cropping empty areas.">
@@ -2318,9 +2326,25 @@
           <choice name="8X" value="8"/>
         </feature>
       </system>
+      <feature submenu="CONTROLS" name="CONTROLLER 1 TYPE" group="ADVANCED SETTINGS" value="pce_controller1">
+        <choice name="JOYPAD" value="1"/>
+        <choice name="MOUSE" value="2"/>
+      </feature>
+      <feature submenu="CONTROLS" name="CONTROLLER 2 TYPE" group="ADVANCED SETTINGS" value="pce_controller2">
+        <choice name="JOYPAD" value="1"/>
+        <choice name="MOUSE" value="2"/>
+      </feature>
     </core>
     <core name="mednafen_pcfx" features="cheevos, netplay">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
+      <feature submenu="CONTROLS" name="CONTROLLER 1 TYPE" group="ADVANCED SETTINGS" value="pcfx_controller1">
+        <choice name="JOYPAD" value="1"/>
+        <choice name="MOUSE" value="2"/>
+      </feature>
+      <feature submenu="CONTROLS" name="CONTROLLER 2 TYPE" group="ADVANCED SETTINGS" value="pcfx_controller2">
+        <choice name="JOYPAD" value="1"/>
+        <choice name="MOUSE" value="2"/>
+      </feature>
     </core>
     <core name="mednafen_psx" features="netplay, cheevos">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
@@ -2686,6 +2710,14 @@
     <core name="mednafen_supergrafx" features="cheevos, netplay">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
+      <feature submenu="CONTROLS" name="PLAYER 1 CONTROLLER TYPE" group="ADVANCED SETTINGS" value="supergrafx_controller1">
+        <choice name="JOYPAD" value="1"/>
+        <choice name="MOUSE" value="2"/>
+      </feature>
+      <feature submenu="CONTROLS" name="PLAYER 2 CONTROLLER TYPE" group="ADVANCED SETTINGS" value="supergrafx_controller2">
+        <choice name="JOYPAD" value="1"/>
+        <choice name="MOUSE" value="2"/>
+      </feature>
     </core>
     <core name="mednafen_vb" features="cheevos, netplay">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
@@ -2768,18 +2800,32 @@
         <choice name="no" value="false"/>
         <choice name="yes" value="true"/>
       </feature>
-      <feature submenu="CONTROLS" name="PLAYER 1 CONTROLER DEVICE" group="ADVANCED SETTINGS" value="input_libretro_device_p1">
-        <choice name="gamepad" value="257"/>
-        <choice name="zapper" value="262"/>
+      <feature submenu="CONTROLS" name="PLAYER 1 CONTROLER DEVICE" group="ADVANCED SETTINGS" value="mesen_controller1">
+        <choice name="GAMEPAD" value="257"/>
+        <choice name="ZAPPER" value="262"/>
+        <choice name="POWER PAD" value="513"/>
+        <choice name="ARKANOID" value="258"/>
       </feature>
-      <feature submenu="CONTROLS" name="PLAYER 2 CONTROLER DEVICE" group="ADVANCED SETTINGS" value="input_libretro_device_p2">
-        <choice name="gamepad" value="257"/>
-        <choice name="zapper" value="262"/>
+      <feature submenu="CONTROLS" name="PLAYER 2 CONTROLER DEVICE" group="ADVANCED SETTINGS" value="mesen_controller2">
+        <choice name="GAMEPAD" value="257"/>
+        <choice name="ZAPPER" value="262"/>
+        <choice name="POWER PAD" value="513"/>
+        <choice name="ARKANOID" value="258"/>
       </feature>
     </core>
     <core name="mesen-s" features="cheevos, netplay">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
+      <feature submenu="CONTROLS" name="PLAYER 1 CONTROLER DEVICE" group="ADVANCED SETTINGS" value="mesen_controller1">
+        <choice name="SNES CONTROLLER" value="257"/>
+        <choice name="MOUSE" value="770"/>
+      </feature>
+      <feature submenu="CONTROLS" name="PLAYER 2 CONTROLER DEVICE" group="ADVANCED SETTINGS" value="mesen_controller2">
+        <choice name="SNES CONTROLLER" value="257"/>
+        <choice name="SUPERSCOPE" value="262"/>
+        <choice name="MOUSE" value="770"/>
+        <choice name="MULTITAP" value="513"/>
+      </feature>
       <sharedFeature submenu="CONTROLS" group="ADVANCED SETTINGS" value="buttonsInvert"/>
     </core>
     <core name="mupen64plus, mupen64plus_next, mupen64plus_next_gles3" features="cheevos, netplay">
@@ -4061,12 +4107,20 @@
         <choice name="1X" value="1x"/>
         <choice name="2X" value="2x"/>
       </feature>
-      <feature submenu="CONTROLS" name="SHIFT A/B/X/Y CLOCKWISE" group="ADVANCED SETTINGS" value="nestopia_button_shift" description="This can help, depending on the controllers for better playability.">
-        <choice name="OFF" value="disabled"/>
-        <choice name="ON" value="enabled"/>
+      <feature submenu="CONTROLS" name="PLAYER 1 CONTROLLER TYPE" group="ADVANCED SETTINGS" value="nestopia_controller1">
+        <choice name="NES GAMEPAD" value="257"/>
+      </feature>
+      <feature submenu="CONTROLS" name="PLAYER 2 CONTROLLER TYPE" group="ADVANCED SETTINGS" value="nestopia_controller2">
+        <choice name="NES GAMEPAD" value="257"/>
+        <choice name="ZAPPER" value="262"/>
+        <choice name="ARKANOID" value="258"/>
       </feature>
       <sharedFeature submenu="CONTROLS" group="ADVANCED SETTINGS" value="use_guns"/>
       <feature submenu="CONTROLS" name="LIGHTGUN CROSSHAIRS" group="ADVANCED SETTINGS" value="nestopia_show_crosshair">
+        <choice name="OFF" value="disabled"/>
+        <choice name="ON" value="enabled"/>
+      </feature>
+      <feature submenu="CONTROLS" name="SHIFT A/B/X/Y CLOCKWISE" group="ADVANCED SETTINGS" value="nestopia_button_shift" description="This can help, depending on the controllers for better playability.">
         <choice name="OFF" value="disabled"/>
         <choice name="ON" value="enabled"/>
       </feature>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -280,6 +280,27 @@
       <choice name="OFF" value="0"/>
       <choice name="ON" value="1"/>
     </feature>
+    <feature name="TURBO MODE" value="enable_turbo">
+      <choice name="CLASSIC" value="0"/>
+      <choice name="TOGGLE" value="1"/>
+      <choice name="HOLD" value="2"/>
+    </feature>
+    <feature name="TURBO ACTIVATION BUTTON" value="turbo_button" description="Define which button activates the turbo mode, this is not the button that is made turbo.">
+      <choice name="LEFT TRIGGER (L2)" value="L2"/>
+      <choice name="RIGHT TRIGGER (R2)" value="R2"/>
+      <choice name="LEFT SHOULDER (L1)" value="L1"/>
+      <choice name="RIGHT SHOULDER (R1)" value="R1"/>
+    </feature>
+    <feature name="TURBO BUTTON" value="turbo_default_button" description="Use this setting to define a default target turbo button.">
+      <choice name="SOUTH (B)" value="0"/>
+      <choice name="WEST (Y)" value="1"/>
+      <choice name="EAST (A)" value="2"/>
+      <choice name="NORTH (X)" value="3"/>
+      <choice name="LEFT SHOULDER (L1)" value="4"/>
+      <choice name="RIGHT SHOULDER (R1)" value="5"/>
+      <choice name="LEFT TRIGGER (L2)" value="6"/>
+      <choice name="RIGHT TRIGGER (R2)" value="7"/>
+    </feature>
     <feature name="AUTOCONFIGURE CONTROLLERS" value="global.disableautocontrollers" preset="switchoff"/>
     <feature name="AUTOCONFIGURE CONTROLLERS" value="disableautocontrollers">
       <choice name="ON" value="0"/>
@@ -3779,6 +3800,9 @@
         <choice name="NO" value="0"/>
         <choice name="YES" value="1"/>
       </feature>
+      <sharedFeature submenu="CONTROLS" group="ADVANCED SETTINGS" value="enable_turbo"/>
+      <sharedFeature submenu="CONTROLS" group="ADVANCED SETTINGS" value="turbo_button"/>
+      <sharedFeature submenu="CONTROLS" group="ADVANCED SETTINGS" value="turbo_default_button"/>
     </core>
     <core name="freeintv" features="cheevos">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -1436,7 +1436,7 @@
         <choice name="2560x1920" value="2560x1920"/>
       </feature>
       <feature submenu="VIDEO" name="EMULATED VIDEO SIGNAL" group="ADVANCED SETTINGS" value="cable_type" description="Apply a video filter to mimic various signals.">
-        <choice name="RGB" value="TV (RGB)"/>
+        <choice name="TV (RGB)" value="TV (RGB)"/>
         <choice name="COMPOSITE" value="TV (Composite)"/>
         <choice name="VGA" value="VGA"/>
       </feature>
@@ -1452,11 +1452,24 @@
         <choice name="NO" value="horizontal"/>
         <choice name="YES" value="vertical"/>
       </feature>
+      <feature submenu="VIDEO" name="FRAMESKIP" group="ADVANCED SETTINGS" value="reicast_frame_skipping" description="Skip frames to improve performance (smoothless).">
+        <choice name="NO" value="disabled"/>
+        <choice name="1" value="1"/>
+        <choice name="2" value="2"/>
+        <choice name="3" value="3"/>
+        <choice name="4" value="4"/>
+        <choice name="5" value="5"/>
+        <choice name="6" value="6"/>
+      </feature>
+	  <feature submenu="VIDEO" name="RENDER TO MULTIPLE THREADS" group="ADVANCED SETTINGS" value="reicast_threaded_rendering" description="Leave this on by default, will use multiple threads for rendering.">
+        <choice name="YES" value="enabled"/>
+        <choice name="NO" value="disabled"/>
+      </feature>
       <feature submenu="VISUAL RENDERING" name="TEXTURES ENHANCEMENT" group="ADVANCED SETTINGS" value="texture_upscaling" description="Enhance hand drawn 2D pixel art graphics.">
-        <choice name="NO" value="off"/>
-        <choice name="2x" value="2x"/>
-        <choice name="4x" value="4x"/>
-        <choice name="6x" value="6x"/>
+        <choice name="NO" value="1"/>
+        <choice name="2x" value="2"/>
+        <choice name="4x" value="4"/>
+        <choice name="6x" value="6"/>
       </feature>
       <feature submenu="VISUAL RENDERING" name="ANISOTROPIC FILTERING" group="ADVANCED SETTINGS" value="anisotropic_filtering" description="Enhance the quality of textures on surface.">
         <choice name="NO" value="off"/>
@@ -3591,10 +3604,9 @@
         <choice name="NO" value="none"/>
         <choice name="WRX" value="WRX"/>
       </feature>
-      <feature submenu="VIDEO" name="BORDER SIZE" group="ADVANCED SETTINGS" value="81_border_size">
-        <choice name="NORMAL" value="normal"/>
-        <choice name="SMALL" value="small"/>
-        <choice name="NO BORDER" value="none"/>
+      <feature submenu="VIDEO" name="HIDE BORDER" group="ADVANCED SETTINGS" value="81_hide_border">
+        <choice name="NO" value="disabled"/>
+        <choice name="YES" value="enabled"/>
       </feature>
       <feature submenu="VISUAL RENDERING" name="VIDEO PRESETS" group="ADVANCED SETTINGS" value="81_video_presets" description="Apply a core-provided video filter.">
         <choice name="CLEAN" value="clean"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -726,10 +726,6 @@
         <choice name="簡化字 (Chinese - traditional)" value="Traditional Chinese"/>
         <choice name="简化字 (Chinese - simplified)" value="Simplified Chinese"/>
       </feature>
-      <feature submenu="CONTROLS" name="SHOW MOUSE POINTER" group="ADVANCED SETTINGS" value="citra_mouse_show_pointer" description="Show the mouse pointer on the emulated touchscreen.">
-        <choice name="NO" value="disabled"/>
-        <choice name="YES" value="enabled"/>
-      </feature>
       <feature submenu="CONTROLS" name="ENABLE MOUSE" group="ADVANCED SETTINGS" value="citra_mouse_touchscreen" description="Choose if the mouse input is active or not.">
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>
@@ -2110,7 +2106,7 @@
     </core>
     <core name="mame2003_plus" features="cheevos, netplay">
       <feature submenu="VIDEO" name="FRAMESKIP" group="ADVANCED SETTINGS" value="mame2003-plus_frameskip" description="Skip frames to improve performance (smoothless).">
-        <choice name="NO" value="0"/>
+        <choice name="NO" value="disabled"/>
         <choice name="1" value="1"/>
         <choice name="2" value="2"/>
         <choice name="3" value="3"/>
@@ -2670,7 +2666,6 @@
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>
       </feature>
-      <sharedFeature submenu="CONTROLS" group="ADVANCED SETTINGS" value="use_guns"/>
       <feature submenu="CONTROLS" name="PLAYER 1 CONTROLLER TYPE" group="ADVANCED SETTINGS" value="saturn_controller1">
         <choice name="JOYPAD" value="1"/>
         <choice name="3D PAD" value="261"/>
@@ -2693,7 +2688,28 @@
         <choice name="VIRTUA GUN" value="260"/>
         <choice name="DUAL MISSION STICKS" value="1029"/>
       </feature>
-      <feature submenu="CONTROLS" name="6 PLAYERS ADAPTOR" group="ADVANCED SETTINGS" value="beetle_saturn_multitap_port1" description="Enable multitap in port 1.">
+      <sharedFeature submenu="CONTROLS" group="ADVANCED SETTINGS" value="use_guns"/>
+      <feature submenu="CONTROLS" name="CROSSHAIR TYPE" group="ADVANCED SETTINGS" value="beetle_saturn_virtuagun_crosshair" description="Define type of crosshair for guns.">
+        <choice name="CROSS" value="Cross"/>
+        <choice name="DOT" value="Dot"/>
+        <choice name="NONE" value="Off"/>
+      </feature>
+      <feature submenu="CONTROLS" name="MOUSE SENSITIVITY" value="beetle_saturn_mouse_sensitivity" group="ADVANCED SETTINGS" description="Change the sensitivity of the mouse.">
+        <choice name="100 (DEFAULT)" value="100%"/>
+        <choice name="50" value="50%"/>
+        <choice name="75" value="75%"/>
+        <choice name="90" value="90%"/>
+        <choice name="95" value="95%"/>
+        <choice name="105" value="105%"/>
+        <choice name="110" value="110%"/>
+        <choice name="125" value="125%"/>
+        <choice name="150" value="150%"/>
+      </feature>
+      <feature submenu="CONTROLS" name="MULTITAP PORT 1" group="ADVANCED SETTINGS" value="beetle_saturn_multitap_port1" description="Enable multitap in port 1.">
+        <choice name="NO" value="disabled"/>
+        <choice name="YES" value="enabled"/>
+      </feature>
+      <feature submenu="CONTROLS" name="MULTITAP PORT 2" group="ADVANCED SETTINGS" value="beetle_saturn_multitap_port2" description="Enable multitap in port 2.">
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>
       </feature>
@@ -3139,10 +3155,6 @@
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
     </core>
     <core name="snes9x" features="cheevos, netplay">
-      <feature name="INTERNAL RESOLUTION" group="GENERAL SETTINGS" value="snes9x_gfx_hires">
-        <choice name="NATIVE" value="disabled"/>
-        <choice name="ENHANCED" value="enabled"/>
-      </feature>
       <feature submenu="VIDEO" name="FORMAT" group="ADVANCED SETTINGS" value="snes9x_region">
         <choice name="NTSC" value="ntsc"/>
         <choice name="PAL" value="pal"/>
@@ -4595,8 +4607,8 @@
         <choice name="Accurate" value="Accurate"/>
       </feature>
       <feature submenu="CONTROLS" name="CONFIRMATION BUTTON" group="ADVANCED SETTINGS" value="ppsspp_button_preference" description="Select whether the cross input or the circle input is the confirmation button.">
-        <choice name="CROSS" value="cross"/>
-        <choice name="CIRCLE" value="circle"/>
+        <choice name="CROSS" value="Cross"/>
+        <choice name="CIRCLE" value="Circle"/>
       </feature>
     </core>
     <core name="prboom">

--- a/batocera-systems/Resources/batocera-systems.json
+++ b/batocera-systems/Resources/batocera-systems.json
@@ -154,6 +154,8 @@
 	
 	"psvita": { "name": "PS Vita", "biosFiles":  [ { "md5": "8b5f60b56c3da8365b973dba570c53a5", "file": "bios/PSP2UPDAT.PUP" },
 	                                               { "md5": "f2c7b12fe85496ec88a0391b514d6e3b", "file": "bios/PSVUPDAT.PUP" } ] },
+                                                   
+	"colecovision": { "name": "ColecoVision", "biosFiles":  [ { "md5": "2c66f5911e5b42b8ebe113403548eee7", "file": "bios/colecovision.rom" } ] },
 
 	"lynx48k": { "name": "Camputers Lynx", "biosFiles": [ { "md5": "85ae78a20ffaff388dd09c75d9e1ec0e", "file": "lynx48k.zip" } ] },
 

--- a/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
+++ b/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
@@ -2367,7 +2367,7 @@ namespace emulatorLauncher.libRetro
                 else
                 {
                     coreSettings["prosystem_low_pass_filter"] = "disabled";
-                    coreSettings["prosystem_low_pass_range"] = "0";
+                    coreSettings["prosystem_low_pass_range"] = "60";
                 }
             }
 
@@ -2386,7 +2386,7 @@ namespace emulatorLauncher.libRetro
             // System options
             BindFeature(coreSettings, "puae_model", "model", "auto");
             BindFeature(coreSettings, "puae_cpu_compatibility", "cpu_compatibility", "normal");
-            BindFeature(coreSettings, "puae_cpu_multiplier", "cpu_multiplier", "default");
+            BindFeature(coreSettings, "puae_cpu_multiplier", "cpu_multiplier", "0");
             BindFeature(coreSettings, "puae_kickstart", "puae_kickstart", "auto");
             BindFeature(coreSettings, "puae_use_whdload_prefs", "whdload", "config");
             BindFeature(coreSettings, "puae_floppy_speed", "floppy_speed", "100");
@@ -2441,10 +2441,10 @@ namespace emulatorLauncher.libRetro
             }
 
             BindFeature(coreSettings, "reicast_anisotropic_filtering", "anisotropic_filtering", "off");
-            BindFeature(coreSettings, "reicast_texupscale", "texture_upscaling", "off");
+            BindFeature(coreSettings, "reicast_texupscale", "texture_upscaling", "1");
             BindFeature(coreSettings, "reicast_render_to_texture_upscaling", "render_to_texture_upscaling", "1x");
             BindFeature(coreSettings, "reicast_force_wince", "force_wince", "disabled");
-            BindFeature(coreSettings, "reicast_cable_type", "cable_type", "VGA (RGB)");
+            BindFeature(coreSettings, "reicast_cable_type", "cable_type", "TV (RGB)");
             BindFeature(coreSettings, "reicast_internal_resolution", "internal_resolution", "640x480");
             BindFeature(coreSettings, "reicast_force_freeplay", "reicast_force_freeplay", "disabled");
             BindFeature(coreSettings, "reicast_allow_service_buttons", "reicast_allow_service_buttons", "disabled");
@@ -2462,8 +2462,15 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "reicast_pvr2_filtering", "reicast_pvr2_filtering", "disabled");
 
             // toadd
-            BindFeature(coreSettings, "reicast_synchronous_rendering", "reicast_synchronous_rendering", "enabled");
-            BindFeature(coreSettings, "reicast_frame_skipping", "reicast_frame_skipping", "disabled");
+            BindFeature(coreSettings, "reicast_threaded_rendering", "reicast_threaded_rendering", "enabled");
+
+            if (SystemConfig.isOptSet("reicast_frame_skipping") && SystemConfig["reicast_frame_skipping"] != "disabled")
+            {
+                coreSettings["reicast_frame_skipping"] = SystemConfig["reicast_frame_skipping"];
+                coreSettings["reicast_threaded_rendering"] = "enabled";
+            }
+            else
+                coreSettings["reicast_frame_skipping"] = "disabled";
 
             // Controls
             BindFeature(retroarchConfig, "input_libretro_device_p1", "flycast_controller1", "1");
@@ -2708,7 +2715,7 @@ namespace emulatorLauncher.libRetro
             if (core != "81")
                 return;
 
-            BindFeature(coreSettings, "81_border_size", "81_border_size", "normal");
+            BindFeature(coreSettings, "81_hide_border", "81_hide_border", "disabled");
             BindFeature(coreSettings, "81_highres", "81_highres", "auto");
             BindFeature(coreSettings, "81_chroma_81", "81_chroma_81", "auto");
             BindFeature(coreSettings, "81_video_presets", "81_video_presets", "clean");
@@ -2736,7 +2743,7 @@ namespace emulatorLauncher.libRetro
                 else
                 {
                     coreSettings["a5200_low_pass_filter"] = "disabled";
-                    coreSettings["a5200_low_pass_range"] = "0";
+                    coreSettings["a5200_low_pass_range"] = "60";
                 }
             }
 
@@ -2846,7 +2853,7 @@ namespace emulatorLauncher.libRetro
                 else
                 {
                     coreSettings["mgba_audio_low_pass_filter"] = "disabled";
-                    coreSettings["mgba_audio_low_pass_range"] = "0";
+                    coreSettings["mgba_audio_low_pass_range"] = "60";
                 }
             }
         }
@@ -2883,7 +2890,7 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "px68k_frameskip", "px68k_frameskip", "Full Frame");
             BindFeature(coreSettings, "px68k_joytype1", "px68k_joytype", "Default (2 Buttons)");
             BindFeature(coreSettings, "px68k_joytype2", "px68k_joytype", "Default (2 Buttons)");
-            BindFeature(coreSettings, "px68k_joy1_select", "px68k_joy1_select", "Full Frame");
+            BindFeature(coreSettings, "px68k_joy1_select", "px68k_joy1_select", "Default");
             BindFeature(coreSettings, "px68k_joy_mouse", "px68k_joy_mouse", "Mouse");
         }
 

--- a/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
+++ b/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
@@ -825,7 +825,7 @@ namespace emulatorLauncher.libRetro
                 else
                 {
                     coreSettings["fba2012cps2_lowpass_filter"] = "disabled";
-                    coreSettings["fba2012cps2_lowpass_range"] = "0";
+                    coreSettings["fba2012cps2_lowpass_range"] = "60";
                 }
             }
 
@@ -854,7 +854,7 @@ namespace emulatorLauncher.libRetro
                 else
                 {
                     coreSettings["fba2012cps1_lowpass_filter"] = "disabled";
-                    coreSettings["fba2012cps1_lowpass_range"] = "0";
+                    coreSettings["fba2012cps1_lowpass_range"] = "60";
                 }
             }
         }
@@ -866,9 +866,9 @@ namespace emulatorLauncher.libRetro
 
             coreSettings["ppsspp_cpu_core"] = "jit";
             coreSettings["ppsspp_auto_frameskip"] = "disabled";
-            coreSettings["ppsspp_frameskip"] = "0";
+            coreSettings["ppsspp_frameskip"] = "Off";
             coreSettings["ppsspp_frameskiptype"] = "number of frames";
-            coreSettings["ppsspp_rendering_mode"] = "buffered";
+            coreSettings["ppsspp_rendering_mode"] = "Buffered";
             coreSettings["ppsspp_locked_cpu_speed"] = "off";
 
             if (Features.IsSupported("cheevos") && SystemConfig.getOptBoolean("retroachievements") && SystemConfig.getOptBoolean("retroachievements.hardcore"))
@@ -880,7 +880,7 @@ namespace emulatorLauncher.libRetro
             {
                 case "Fast":
                     coreSettings["ppsspp_block_transfer_gpu"] = "disabled";
-                    coreSettings["ppsspp_spline_quality"] = "low";
+                    coreSettings["ppsspp_spline_quality"] = "Low";
                     coreSettings["ppsspp_software_skinning"] = "enabled";
                     coreSettings["ppsspp_gpu_hardware_transform"] = "enabled";
                     coreSettings["ppsspp_vertex_cache"] = "enabled";
@@ -892,7 +892,7 @@ namespace emulatorLauncher.libRetro
                     break;
                 case "Balanced":
                     coreSettings["ppsspp_block_transfer_gpu"] = "enabled";
-                    coreSettings["ppsspp_spline_quality"] = "medium";
+                    coreSettings["ppsspp_spline_quality"] = "Medium";
                     coreSettings["ppsspp_software_skinning"] = "disabled";
                     coreSettings["ppsspp_gpu_hardware_transform"] = "enabled";
                     coreSettings["ppsspp_vertex_cache"] = "enabled";
@@ -904,7 +904,7 @@ namespace emulatorLauncher.libRetro
                     break;
                 case "Accurate":
                     coreSettings["ppsspp_block_transfer_gpu"] = "enabled";
-                    coreSettings["ppsspp_spline_quality"] = "high";
+                    coreSettings["ppsspp_spline_quality"] = "High";
                     coreSettings["ppsspp_software_skinning"] = "disabled";
                     coreSettings["ppsspp_gpu_hardware_transform"] = "disabled";
                     coreSettings["ppsspp_vertex_cache"] = "disabled";
@@ -916,7 +916,7 @@ namespace emulatorLauncher.libRetro
                     break;
                 default:
                     coreSettings["ppsspp_block_transfer_gpu"] = "enabled";
-                    coreSettings["ppsspp_spline_quality"] = "medium";
+                    coreSettings["ppsspp_spline_quality"] = "Medium";
                     coreSettings["ppsspp_software_skinning"] = "enabled";
                     coreSettings["ppsspp_gpu_hardware_transform"] = "enabled";
                     coreSettings["ppsspp_vertex_cache"] = "disabled";
@@ -930,15 +930,15 @@ namespace emulatorLauncher.libRetro
 
             BindFeature(coreSettings, "ppsspp_internal_resolution", "ppsspp_internal_resolution", "1440x816");
             BindFeature(coreSettings, "ppsspp_texture_anisotropic_filtering", "ppsspp_texture_anisotropic_filtering", "off");
-            BindFeature(coreSettings, "ppsspp_texture_filtering", "ppsspp_texture_filtering", "auto");
+            BindFeature(coreSettings, "ppsspp_texture_filtering", "ppsspp_texture_filtering", "Auto");
             BindFeature(coreSettings, "ppsspp_texture_scaling_type", "ppsspp_texture_scaling_type", "xbrz");
-            BindFeature(coreSettings, "ppsspp_texture_scaling_level", "ppsspp_texture_scaling_level", "auto");
+            BindFeature(coreSettings, "ppsspp_texture_scaling_level", "ppsspp_texture_scaling_level", "Off");
             BindFeature(coreSettings, "ppsspp_texture_deposterize", "ppsspp_texture_deposterize", "disabled");
-            BindFeature(coreSettings, "ppsspp_language", "ppsspp_language", "automatic");
+            BindFeature(coreSettings, "ppsspp_language", "ppsspp_language", "Automatic");
             BindFeature(coreSettings, "ppsspp_io_timing_method", "ppsspp_io_timing_method", "Fast");
             BindFeature(coreSettings, "ppsspp_ignore_bad_memory_access", "ppsspp_ignore_bad_memory_access", "enabled");
             BindFeature(coreSettings, "ppsspp_texture_replacement", "ppsspp_texture_replacement", "disabled");
-            BindFeature(coreSettings, "ppsspp_button_preference", "ppsspp_button_preference", "cross");
+            BindFeature(coreSettings, "ppsspp_button_preference", "ppsspp_button_preference", "Cross");
             BindFeature(coreSettings, "ppsspp_mulitsample_level", "ppsspp_mulitsample_level", "Disabled");
         }
 
@@ -1025,7 +1025,6 @@ namespace emulatorLauncher.libRetro
 
             BindFeature(coreSettings, "citra_analog_function", "citra_analog_function", "C-Stick and Touchscreen Pointer");
             BindFeature(coreSettings, "citra_mouse_touchscreen", "citra_mouse_touchscreen", "enabled");
-            BindFeature(coreSettings, "citra_mouse_show_pointer", "citra_mouse_show_pointer", "enabled");
         }
 
         private void ConfigureMednafenSaturn(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
@@ -1046,14 +1045,14 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "beetle_saturn_region", "beetle_saturn_region", "Auto Detect");
 
             // NEW
-            BindFeature(coreSettings, "beetle_saturn_virtuagun_crosshair", "beetle_saturn_virtuagun_crosshair", "cross", true);
+            BindFeature(coreSettings, "beetle_saturn_virtuagun_crosshair", "beetle_saturn_virtuagun_crosshair", "Cross", true);
             BindFeature(coreSettings, "beetle_saturn_mouse_sensitivity", "beetle_saturn_mouse_sensitivity", "100%");
-            BindFeature(coreSettings, "beetle_saturn_virtuagun_input", "beetle_saturn_virtuagun_input", "lightgun", true);
 
             // Controls
             BindFeature(retroarchConfig, "input_libretro_device_p1", "saturn_controller1", "1");
             BindFeature(retroarchConfig, "input_libretro_device_p2", "saturn_controller2", "1");
-
+            
+            coreSettings["beetle_saturn_virtuagun_input"] = "Lightgun";
             SetupLightGuns(retroarchConfig, "260");
         }
 
@@ -1093,7 +1092,7 @@ namespace emulatorLauncher.libRetro
                 else
                 {
                     coreSettings["picodrive_audio_filter"] = "disabled";
-                    coreSettings["picodrive_lowpass_range"] = "0";
+                    coreSettings["picodrive_lowpass_range"] = "60";
                 }
             }
         }
@@ -1188,7 +1187,7 @@ namespace emulatorLauncher.libRetro
                 else
                 {
                     coreSettings["pokemini_lowpass_filter"] = "disabled";
-                    coreSettings["pokemini_lowpass_range"] = "0";
+                    coreSettings["pokemini_lowpass_range"] = "60";
                 }
             }
 
@@ -1277,10 +1276,10 @@ namespace emulatorLauncher.libRetro
 
         static List<KeyValuePair<string, string>> operaHacks = new List<KeyValuePair<string, string>>()
             {
-                new KeyValuePair<string, string>("crashnburn", "timing_hack1"),
-                new KeyValuePair<string, string>("dinopark tycoon", "timing_hack3"),
-                new KeyValuePair<string, string>("microcosm", "timing_hack5"),
-                new KeyValuePair<string, string>("aloneinthedark", "timing_hack6"),
+                new KeyValuePair<string, string>("crashnburn", "hack_timing_1"),
+                new KeyValuePair<string, string>("dinopark tycoon", "hack_timing_3"),
+                new KeyValuePair<string, string>("microcosm", "hack_timing_5"),
+                new KeyValuePair<string, string>("aloneinthedark", "hack_timing_6"),
                 new KeyValuePair<string, string>("samuraishowdown", "hack_graphics_step_y")
             };
 
@@ -1357,7 +1356,7 @@ namespace emulatorLauncher.libRetro
                 else
                 {
                     coreSettings["stella2014_low_pass_filter"] = "disabled";
-                    coreSettings["stella2014_low_pass_range"] = "0";
+                    coreSettings["stella2014_low_pass_range"] = "60";
                 }
             }
         }
@@ -1565,7 +1564,7 @@ namespace emulatorLauncher.libRetro
                 else
                 {
                     coreSettings["o2em_low_pass_filter"] = "disabled";
-                    coreSettings["o2em_low_pass_range"] = "0";
+                    coreSettings["o2em_low_pass_range"] = "60";
                 }
             }
         }
@@ -1591,7 +1590,7 @@ namespace emulatorLauncher.libRetro
             coreSettings["mame2003-plus_xy_device"] = "lightgun";
 
             BindFeature(coreSettings, "mame2003-plus_analog", "mame2003-plus_analog", "digital");
-            BindFeature(coreSettings, "mame2003-plus_frameskip", "mame2003-plus_frameskip", "0");
+            BindFeature(coreSettings, "mame2003-plus_frameskip", "mame2003-plus_frameskip", "disabled");
             BindFeature(coreSettings, "mame2003-plus_input_interface", "mame2003-plus_input_interface", "retropad");
             BindFeature(coreSettings, "mame2003-plus_neogeo_bios", "mame2003-plus_neogeo_bios", "unibios33");
             BindFeature(coreSettings, "mame2003-plus_tate_mode", "mame2003-plus_tate_mode", "disabled");
@@ -1619,7 +1618,7 @@ namespace emulatorLauncher.libRetro
             if (core != "cap32")
                 return;
 
-            coreSettings["cap32_autorun"] = "autorun";
+            coreSettings["cap32_autorun"] = "enabled";
 
             // Virtual Keyboard by default (select+start) change to (start+Y)
             coreSettings["cap32_combokey"] = "y";
@@ -1795,7 +1794,6 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "snes9x_blargg", "snes9x_blargg", "disabled"); // Emulated video signal
             BindFeature(coreSettings, "snes9x_overscan", "snes9x_overscan", "auto"); // Overscan
             BindFeature(coreSettings, "snes9x_region", "snes9x_region", "auto"); // Region
-            BindFeature(coreSettings, "snes9x_gfx_hires", "snes9x_gfx_hires", "disabled"); // Internal resolution
             BindFeature(coreSettings, "snes9x_hires_blend", "snes9x_hires_blend", "disabled"); // Pixel blending
             BindFeature(coreSettings, "snes9x_audio_interpolation", "snes9x_audio_interpolation", "none"); // Audio interpolation
             BindFeature(coreSettings, "snes9x_overclock_superfx", "snes9x_overclock_superfx", "100%"); // SuperFX overclock
@@ -1959,7 +1957,7 @@ namespace emulatorLauncher.libRetro
                 else
                 {
                     coreSettings["genesis_plus_gx_audio_filter"] = "disabled";
-                    coreSettings["genesis_plus_gx_lowpass_range"] = "0";
+                    coreSettings["genesis_plus_gx_lowpass_range"] = "60";
                 }
             }
 
@@ -2037,7 +2035,7 @@ namespace emulatorLauncher.libRetro
                 else
                 {
                     coreSettings["genesis_plus_gx_wide_audio_filter"] = "disabled";
-                    coreSettings["genesis_plus_gx_wide_lowpass_range"] = "0";
+                    coreSettings["genesis_plus_gx_wide_lowpass_range"] = "60";
                 }
             }
 
@@ -2093,7 +2091,7 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "mame_alternate_renderer", "alternate_renderer", "disabled");
             BindFeature(coreSettings, "mame_altres", "internal_resolution", "640x480");
             BindFeature(coreSettings, "mame_cheats_enable", "cheats_enable", "disabled");
-            BindFeature(coreSettings, "mame_mame_4way_enable", "4way_enable", "enabled");
+            BindFeature(coreSettings, "mame_mame_4way_enable", "4way_enable", "disabled");
             BindFeature(coreSettings, "mame_lightgun_mode", "lightgun_mode", "lightgun");
 
             BindFeature(coreSettings, "mame_boot_from_cli", "boot_from_cli", "enabled", true);
@@ -2183,7 +2181,6 @@ namespace emulatorLauncher.libRetro
 
             }
 
-            //coreSettings["mupen64plus-cpucore"] = "pure_interpreter";
             coreSettings["mupen64plus-rsp-plugin"] = "hle";
             coreSettings["mupen64plus-EnableLODEmulation"] = "True";
             coreSettings["mupen64plus-EnableCopyAuxToRDRAM"] = "True";
@@ -2300,11 +2297,11 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "mupen64plus-txFilterMode", "Texture_filter", "None");
 
             // Parallel
-            BindFeature(coreSettings, "mupen64plus-parallel-rdp-deinterlace-method", "mupen64plus-parallel-rdp-deinterlace-method", "none");
+            BindFeature(coreSettings, "mupen64plus-parallel-rdp-deinterlace-method", "mupen64plus-parallel-rdp-deinterlace-method", "Bob");
             BindFeature(coreSettings, "mupen64plus-parallel-rdp-dither-filter", "mupen64plus-parallel-rdp-dither-filter", "True");
             BindFeature(coreSettings, "mupen64plus-parallel-rdp-divot-filter", "mupen64plus-parallel-rdp-divot-filter", "True");
             BindFeature(coreSettings, "mupen64plus-parallel-rdp-downscaling", "mupen64plus-parallel-rdp-downscaling", "disable");
-            BindFeature(coreSettings, "mupen64plus-parallel-rdp-gamma-dither", "mupen64plus-parallel-rdp-gamma-dither", "disable");
+            BindFeature(coreSettings, "mupen64plus-parallel-rdp-gamma-dither", "mupen64plus-parallel-rdp-gamma-dither", "False");
             BindFeature(coreSettings, "mupen64plus-parallel-rdp-native-texture-lod", "mupen64plus-parallel-rdp-native-texture-lod", "False");
             BindFeature(coreSettings, "mupen64plus-parallel-rdp-overscan", "mupen64plus-parallel-rdp-overscan", "16");
             BindFeature(coreSettings, "mupen64plus-parallel-rdp-super-sampled-read-back", "mupen64plus-parallel-rdp-super-sampled-read-back", "False");
@@ -2320,8 +2317,6 @@ namespace emulatorLauncher.libRetro
                 return;
 
             coreSettings["dosbox_pure_advanced"] = "true";
-            coreSettings["dosbox_pure_auto_mapping"] = "true";
-            coreSettings["dosbox_pure_bind_unused"] = "true";
             coreSettings["dosbox_pure_savestate"] = "on";
             retroarchConfig["video_font_enable"] = "false"; // Disable OSD for dosbox_pure
 

--- a/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
+++ b/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
@@ -129,7 +129,7 @@ namespace emulatorLauncher.libRetro
                 { "mednafen_psx_hw", "Beetle PSX HW" },
                 { "mednafen_psx", "Beetle PSX" },
                 { "mednafen_saturn", "Beetle Saturn" },
-                { "mednafen_snes", "Beetle bsnes" },
+                { "mednafen_snes", "Mednafen bSNES" },
                 { "mednafen_supafaust", "Beetle Supafaust" },
                 { "mednafen_supergrafx", "Beetle SuperGrafx" },
                 { "mednafen_vb", "Beetle VB" },
@@ -299,7 +299,10 @@ namespace emulatorLauncher.libRetro
             ConfigureMupen64(retroarchConfig, coreSettings, system, core);
             ConfigureFlycast(retroarchConfig, coreSettings, system, core);
             ConfigureMesen(retroarchConfig, coreSettings, system, core);
+            ConfigureMesenS(retroarchConfig, coreSettings, system, core);
             ConfigureMednafenPsxHW(retroarchConfig, coreSettings, system, core);
+            ConfigureMednafenSuperGrafx(retroarchConfig, coreSettings, system, core);
+            ConfigureMednafenPCFX(retroarchConfig, coreSettings, system, core);
             ConfigureGenesisPlusGX(retroarchConfig, coreSettings, system, core);
             ConfigureGenesisPlusGXWide(retroarchConfig, coreSettings, system, core);
             ConfigureDosboxPure(retroarchConfig, coreSettings, system, core);
@@ -314,6 +317,7 @@ namespace emulatorLauncher.libRetro
             ConfigureFbalphaCPS2(retroarchConfig, coreSettings, system, core);
             ConfigureFbalphaCPS3(retroarchConfig, coreSettings, system, core);
             ConfigureMednafenPce(retroarchConfig, coreSettings, system, core);
+            ConfigureMednafenPceFast(retroarchConfig, coreSettings, system, core);
             ConfigureNeocd(retroarchConfig, coreSettings, system, core);
             Configure4Do(retroarchConfig, coreSettings, system, core);
             Configure81(retroarchConfig, coreSettings, system, core);
@@ -734,6 +738,20 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "pce_adpcmvolume", "pcecdvolume", "100");
             BindFeature(coreSettings, "pce_cddavolume", "pcecdvolume", "100");
             BindFeature(coreSettings, "pce_cdpsgvolume", "pcecdvolume", "100");
+
+            // Controls
+            BindFeature(retroarchConfig, "input_libretro_device_p1", "pce_controller1", "1");
+            BindFeature(retroarchConfig, "input_libretro_device_p2", "pce_controller2", "1");
+        }
+
+        private void ConfigureMednafenPceFast(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
+        {
+            if (core != "mednafen_pce_fast")
+                return;
+
+            // Controls
+            BindFeature(retroarchConfig, "input_libretro_device_p1", "pce_controller1", "1");
+            BindFeature(retroarchConfig, "input_libretro_device_p2", "pce_controller2", "1");
         }
 
         private void ConfigureFbalpha(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
@@ -1237,7 +1255,7 @@ namespace emulatorLauncher.libRetro
             BindFeature(retroarchConfig, "input_libretro_device_p3", "kronos_controller3", "1");
             BindFeature(retroarchConfig, "input_libretro_device_p4", "kronos_controller4", "1");
 
-            SetupLightGuns(retroarchConfig, "260");
+            SetupLightGuns(retroarchConfig, "2");     // Kronos does not have device 260, only mouse "2"
         }
 
         private void ConfigureHandy(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
@@ -1504,6 +1522,10 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "nestopia_show_crosshair", "nestopia_show_crosshair", "disabled");
             BindFeature(coreSettings, "nestopia_favored_system", "nestopia_favored_system", "auto");
             BindFeature(coreSettings, "nestopia_button_shift", "nestopia_button_shift", "disabled");
+
+            // Controls
+            BindFeature(retroarchConfig, "input_libretro_device_p1", "nestopia_controller1", "1");
+            BindFeature(retroarchConfig, "input_libretro_device_p2", "nestopia_controller2", "1");
 
             coreSettings["nestopia_zapper_device"] = "lightgun";
             SetupLightGuns(retroarchConfig, "262", 2);
@@ -2470,6 +2492,22 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "mesen_shift_buttons_clockwise", "shift_buttons", "disabled");
             BindFeature(coreSettings, "mesen_fake_stereo", "fake_stereo", "disabled");
 
+            // Controls
+            BindFeature(retroarchConfig, "input_libretro_device_p1", "mesen_controller1", "1");
+            BindFeature(retroarchConfig, "input_libretro_device_p2", "mesen_controller2", "1");
+
+            SetupLightGuns(retroarchConfig, "262", 2);
+        }
+
+        private void ConfigureMesenS(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
+        {
+            if (core != "mesen-s")
+                return;
+
+            // Controls
+            BindFeature(retroarchConfig, "input_libretro_device_p1", "mesen_controller1", "1");
+            BindFeature(retroarchConfig, "input_libretro_device_p2", "mesen_controller2", "1");
+
             SetupLightGuns(retroarchConfig, "262", 2);
         }
 
@@ -2921,6 +2959,25 @@ namespace emulatorLauncher.libRetro
 
             BindFeature(coreSettings, "X1_RESOLUTE", "x1_resolute", "LOW");
         }
+
+        private void ConfigureMednafenSuperGrafx(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
+        {
+            if (core != "mednafen_supergrafx")
+                return;
+
+            BindFeature(retroarchConfig, "input_libretro_device_p1", "supergrafx_controller1", "1");
+            BindFeature(retroarchConfig, "input_libretro_device_p2", "supergrafx_controller2", "1");
+        }
+
+        private void ConfigureMednafenPCFX(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)
+        {
+            if (core != "mednafen_pcfx")
+                return;
+
+            BindFeature(retroarchConfig, "input_libretro_device_p1", "pcfx_controller1", "1");
+            BindFeature(retroarchConfig, "input_libretro_device_p2", "pcfx_controller2", "1");
+        }
+
 
         #region Input remaps
         private Dictionary<string, string> InputRemap = new Dictionary<string, string>();

--- a/emulatorLauncher/Generators/Libretro.Controllers.cs
+++ b/emulatorLauncher/Generators/Libretro.Controllers.cs
@@ -352,26 +352,6 @@ namespace emulatorLauncher.libRetro
             foreach (var key in generatedConfig)
                 retroconfig[key.Key] = key.Value;
 
-            if (controller.Name == "Keyboard")
-                return;
-
-            // Seul sdl2 reconnait le bouton Guide
-            retroconfig["input_joypad_driver"] = _inputDriver;
-
-            int index = controller.DeviceIndex;
-            if (index < 0)
-                index = controller.PlayerIndex - 1;
-
-            if (_inputDriver == "sdl2" && !string.IsNullOrEmpty(controller.DevicePath) && controller.SdlController != null)
-                index = controller.SdlController.Index;
-            else if (_inputDriver == "dinput" && controller.DirectInput != null && controller.DirectInput.DeviceIndex >= 0)
-                index = controller.DirectInput.DeviceIndex;
-            else if (_inputDriver == "xinput" && controller.XInput != null && controller.XInput.DeviceIndex >= 0)
-                index = controller.XInput.DeviceIndex;
-
-            retroconfig[string.Format("input_player{0}_joypad_index", controller.PlayerIndex)] = index.ToString();
-            retroconfig[string.Format("input_player{0}_analog_dpad_mode", controller.PlayerIndex)] = GetAnalogMode(controller, system);
-
             /// Turbo button (if shared feature is set)
             /// input_player{0}_turbo_{1} = turbo activation button (turbokey)
             /// input_turbo_default_button = button that is turbo'ed (turbo_default_button)
@@ -383,7 +363,7 @@ namespace emulatorLauncher.libRetro
             {
                 // Define turbo mode
                 retroconfig["input_turbo_mode"] = Program.SystemConfig["enable_turbo"];
-                
+
                 // Set up a default turbo button if selected (this is the target button to be turbo'd and is necessary in HOLD mode)
                 if (Program.SystemConfig.isOptSet("turbo_default_button") && !string.IsNullOrEmpty(Program.SystemConfig["turbo_default_button"]))
                     retroconfig["input_turbo_default_button"] = Program.SystemConfig["turbo_default_button"];
@@ -399,9 +379,14 @@ namespace emulatorLauncher.libRetro
                     {
                         turbokey = turbobuttons[turbobutton];
                         var input = GetInputCode(controller, turbokey);
-                        retroconfig[string.Format("input_player{0}_turbo_{1}", controller.PlayerIndex, typetoname[input.Type])] = GetConfigValue(input);
+                        if (controller.Name == "Keyboard")
+                        {
+                            retroconfig[string.Format("input_player{0}_turbo", controller.PlayerIndex)] = GetConfigValue(input);
+                        }
+                        else
+                            retroconfig[string.Format("input_player{0}_turbo_{1}", controller.PlayerIndex, typetoname[input.Type])] = GetConfigValue(input);
                     }
-                    
+
                     else
                     {
                         retroconfig[string.Format("input_player{0}_turbo_btn", controller.PlayerIndex)] = "nul";
@@ -421,6 +406,26 @@ namespace emulatorLauncher.libRetro
                 retroconfig[string.Format("input_player{0}_turbo_btn", controller.PlayerIndex)] = "nul";
                 retroconfig[string.Format("input_player{0}_turbo_axis", controller.PlayerIndex)] = "nul";
             }
+
+            if (controller.Name == "Keyboard")
+                return;
+
+            // Seul sdl2 reconnait le bouton Guide
+            retroconfig["input_joypad_driver"] = _inputDriver;
+
+            int index = controller.DeviceIndex;
+            if (index < 0)
+                index = controller.PlayerIndex - 1;
+
+            if (_inputDriver == "sdl2" && !string.IsNullOrEmpty(controller.DevicePath) && controller.SdlController != null)
+                index = controller.SdlController.Index;
+            else if (_inputDriver == "dinput" && controller.DirectInput != null && controller.DirectInput.DeviceIndex >= 0)
+                index = controller.DirectInput.DeviceIndex;
+            else if (_inputDriver == "xinput" && controller.XInput != null && controller.XInput.DeviceIndex >= 0)
+                index = controller.XInput.DeviceIndex;
+
+            retroconfig[string.Format("input_player{0}_joypad_index", controller.PlayerIndex)] = index.ToString();
+            retroconfig[string.Format("input_player{0}_analog_dpad_mode", controller.PlayerIndex)] = GetAnalogMode(controller, system);
         }
 
         public static string GetConfigValue(Input input)


### PR DESCRIPTION
- Finalization of choice of controller type for cores where we have generator
- Fixed many default features values in EL (value was not in the list of values available in RetroArch core options, or typo errors (capital letters...)).
- Added shared feature for turbo button (only available for FCEUMM yet
- Added bios check for Gearcoleco (mandatory bios for this core)