### PR TITLE
cemu - controller stuff

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -3129,6 +3129,7 @@
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>
       </feature>
+      <sharedFeature submenu="CONTROLS" group="ADVANCED SETTINGS" value="use_guns"/>
       <feature submenu="CONTROLS" name="OVERLAY SHOW MOUSE CURSOR" group="ADVANCED SETTINGS" value="ShowCursor">
         <choice name="no" value="false"/>
         <choice name="yes" value="true"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -5744,6 +5744,14 @@
       <choice name="75%" value="0.75"/>
       <choice name="100%" value="1"/>
     </feature>
+    <feature submenu="CONTROLS" name="PLAYER 1 CONTROLLER TYPE" group="ADVANCED SETTINGS" value="cemu_controllerp0" description="Default to WIIU Gamepad, change this for games that do not accept WIIU Gamepad in multiplayer mode.">
+      <choice name="GAMEPAD" value="gamepad"/>
+      <choice name="PRO CONTROLLER" value="procontroller"/>
+    </feature>
+    <feature submenu="CONTROLS" name="PLAYER 2 CONTROLLER TYPE" group="ADVANCED SETTINGS" value="cemu_controllerp1" description="Default to WIIU Gamepad, change this for games that do not accept two WIIU Gamepad in multiplayer mode.">
+      <choice name="GAMEPAD" value="gamepad"/>
+      <choice name="PRO CONTROLLER" value="procontroller"/>
+    </feature>
     <feature submenu="CONTROLS" name="ENABLE MOTION" group="ADVANCED SETTINGS" value="cemu_enable_motion" description="Can only be used if the controller is compatible with motion control.">
       <choice name="NO" value="false"/>
       <choice name="YES" value="true"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -4473,13 +4473,13 @@
       </feature>
     </core>
     <core name="nestopia" features="cheevos, netplay">
-      <feature submenu="VIDEO" name="EMULATED VIDEO SIGNAL" value="nestopia_blargg_ntsc_filter" description="Enable blargg NTSC video filters">
+      <feature submenu="VIDEO" name="EMULATED VIDEO SIGNAL" group="ADVANCED SETTINGS" value="nestopia_blargg_ntsc_filter" description="Enable blargg NTSC video filters">
         <choice name="OFF" value="disabled"/>
         <choice name="Composite (color bleeding + artifacts)" value="composite"/>
         <choice name="SVideo (color bleeding only)" value="svideo"/>
         <choice name="RGB (crisp image)" value="rgb"/>
       </feature>
-      <feature submenu="VIDEO" name="CROP OVERSCAN" value="nestopia_cropoverscan" description="Zooms in to hide black borders. Borders are different per game.">
+      <feature submenu="VIDEO" name="CROP OVERSCAN" group="ADVANCED SETTINGS" value="nestopia_cropoverscan" description="Zooms in to hide black borders. Borders are different per game.">
         <choice name="OFF" value="none"/>
         <choice name="Horizontal" value="h"/>
         <choice name="Vertical" value="v"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -5752,6 +5752,13 @@
       <choice name="GAMEPAD" value="gamepad"/>
       <choice name="PRO CONTROLLER" value="procontroller"/>
     </feature>
+    <feature submenu="CONTROLS" name="TRUE WIIMOTES" group="ADVANCED SETTINGS" value="use_wiimotes" description="Play with real wiimotes only, other controllers will not work.">
+      <choice name="NO" value="0"/>
+      <choice name="1 WIIMOTE" value="1"/>
+      <choice name="2 WIIMOTES" value="2"/>
+      <choice name="3 WIIMOTES" value="3"/>
+      <choice name="4 WIIMOTES" value="4"/>
+    </feature>
     <feature submenu="CONTROLS" name="ENABLE MOTION" group="ADVANCED SETTINGS" value="cemu_enable_motion" description="Can only be used if the controller is compatible with motion control.">
       <choice name="NO" value="false"/>
       <choice name="YES" value="true"/>

--- a/emulatorLauncher/Generators/Cemu.Controllers.cs
+++ b/emulatorLauncher/Generators/Cemu.Controllers.cs
@@ -180,10 +180,9 @@ namespace emulatorLauncher
         }
 
         /// <summary>
-        /// Joysticks configuration
+        /// Wiimote configuration
         /// </summary>
         /// <param name="writer"></param>
-        /// <param name="ctrl"></param>
         /// <param name="playerIndex"></param>
         private static void ConfigureWiimotes(XmlWriter writer, int playerIndex)
         {

--- a/emulatorLauncher/Generators/Cemu.Controllers.cs
+++ b/emulatorLauncher/Generators/Cemu.Controllers.cs
@@ -195,10 +195,22 @@ namespace emulatorLauncher
 
             string uuid = index + "_" + ctrl.GetSdlGuid(SdlVersion.SDL2_0_X).ToLowerInvariant(); //string uuid of the cemu config file, based on old sdl2 guids ( pre 2.26 ) without crc-16
 
-            //WiiU and cemu only allow 2 Gamepads, players 1&2 will be set as Gamepads, following players as Pro Controller(s)
+            // Define type of controller
+            // Players 1 & 2 defaults to WIIU Gamepad but can be changed to pro controller in features for some multiplayer games compatibility
+            // Players 3 and 4 default to pro controllers
             bool procontroller = false;
             if (playerIndex == 0 || playerIndex == 1)
-                type = "Wii U GamePad";
+            {
+                string cemuController = "cemu_controllerp" + playerIndex;
+                if (Program.SystemConfig.isOptSet(cemuController) && (Program.SystemConfig[cemuController] == "procontroller"))
+                {
+                    type = "Wii U Pro Controller";
+                    procontroller = true;
+                }
+                else
+                    type = "Wii U GamePad";
+            }
+
             else
             {
                 type = "Wii U Pro Controller";

--- a/emulatorLauncher/Generators/Cemu.Controllers.cs
+++ b/emulatorLauncher/Generators/Cemu.Controllers.cs
@@ -49,21 +49,39 @@ namespace emulatorLauncher
             if (!Directory.Exists(folder))
                 Directory.CreateDirectory(folder);
 
-            // Create a single controllerprofile file for each controller
-            foreach (var controller in this.Controllers)
+            // If Wiimotes is set, do not use ES controllers but force wiimotes
+            if (Program.SystemConfig.isOptSet("use_wiimotes") && (Program.SystemConfig["use_wiimotes"] != "0"))
             {
-                if (controller.Config == null)
-                    continue;
-
-                string controllerXml = Path.Combine(folder, "controller" + (controller.PlayerIndex - 1) + ".xml");
-
-                // Create xml file with correct settings
-                var settings = new XmlWriterSettings() { Encoding = Encoding.UTF8, Indent = true, IndentChars = ("\t"), OmitXmlDeclaration = false };
-
-                // Go to input configuration
-                using (XmlWriter writer = XmlWriter.Create(controllerXml, settings))
-                    ConfigureInputXml(writer, controller);
+                int nbWiimotes = SystemConfig["use_wiimotes"].ToInteger();
+                
+                for (int i = 0; i <= nbWiimotes - 1; i++)
+                {
+                    string controllerXml = Path.Combine(folder, "controller" + i + ".xml");
+                    var settings = new XmlWriterSettings() { Encoding = Encoding.UTF8, Indent = true, IndentChars = ("\t"), OmitXmlDeclaration = false };
+                    using (XmlWriter writer = XmlWriter.Create(controllerXml, settings))
+                        ConfigureWiimotes(writer, i);
+                }
             }
+
+            else
+            {
+                // Create a single controllerprofile file for each controller
+                foreach (var controller in this.Controllers)
+                {
+                    if (controller.Config == null)
+                        continue;
+
+                    string controllerXml = Path.Combine(folder, "controller" + (controller.PlayerIndex - 1) + ".xml");
+
+                    // Create xml file with correct settings
+                    var settings = new XmlWriterSettings() { Encoding = Encoding.UTF8, Indent = true, IndentChars = ("\t"), OmitXmlDeclaration = false };
+
+                    // Go to input configuration
+                    using (XmlWriter writer = XmlWriter.Create(controllerXml, settings))
+                        ConfigureInputXml(writer, controller);
+                }
+            }
+
         }
 
         /// <summary>
@@ -155,6 +173,77 @@ namespace emulatorLauncher
             WriteInputKeyMapping("26", InputKey.hotkey);
 
             //close xml elements
+            writer.WriteEndElement();//end of mappings
+            writer.WriteEndElement();//end of controller
+            writer.WriteEndElement();//end of emulated_controller
+            writer.WriteEndDocument();
+        }
+
+        /// <summary>
+        /// Joysticks configuration
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="ctrl"></param>
+        /// <param name="playerIndex"></param>
+        private static void ConfigureWiimotes(XmlWriter writer, int playerIndex)
+        {
+            //Create start of the xml document until mappings part
+            writer.WriteStartDocument();
+            writer.WriteStartElement("emulated_controller");
+            writer.WriteElementString("type", "Wiimote");
+            writer.WriteStartElement("controller");
+            writer.WriteElementString("api", "Wiimote");
+            writer.WriteElementString("uuid", playerIndex.ToString());
+            writer.WriteElementString("display_name", "Controller" + (playerIndex + 1).ToString());
+            writer.WriteElementString("motion", "true");
+
+            //set rumble if option is set
+            if (Program.SystemConfig.isOptSet("cemu_enable_rumble") && !string.IsNullOrEmpty(Program.SystemConfig["cemu_enable_rumble"]))
+                writer.WriteElementString("rumble", Program.SystemConfig["cemu_enable_rumble"]);
+
+            //Default deadzones and ranges for axis, rotation and trigger
+            writer.WriteStartElement("axis");
+            writer.WriteElementString("deadzone", "0.25");
+            writer.WriteElementString("range", "1");
+            writer.WriteEndElement();//end of axis
+            writer.WriteStartElement("rotation");
+            writer.WriteElementString("deadzone", "0.25");
+            writer.WriteElementString("range", "1");
+            writer.WriteEndElement();//end of rotation
+            writer.WriteStartElement("trigger");
+            writer.WriteElementString("deadzone", "0.25");
+            writer.WriteElementString("range", "1");
+            writer.WriteEndElement();//end of trigger
+            writer.WriteElementString("packet_delay", "25");
+            writer.WriteStartElement("mappings");
+
+            //Define action to generate key bindings
+            Action<string, string> WriteWiimoteMapping = (m, b) =>
+            {
+                writer.WriteStartElement("entry");
+                writer.WriteElementString("mapping", m);
+                writer.WriteElementString("button", b);
+                writer.WriteEndElement();
+            };
+
+            WriteWiimoteMapping("9", "3");
+            WriteWiimoteMapping("17", "15");
+            WriteWiimoteMapping("1", "11");
+            WriteWiimoteMapping("2", "10");
+            WriteWiimoteMapping("3", "9");
+            WriteWiimoteMapping("4", "8");
+            WriteWiimoteMapping("7", "4");
+            WriteWiimoteMapping("8", "12");
+            WriteWiimoteMapping("10", "2");
+            WriteWiimoteMapping("11", "0");
+            WriteWiimoteMapping("12", "1");
+            WriteWiimoteMapping("5", "17");
+            WriteWiimoteMapping("6", "16");
+            WriteWiimoteMapping("13", "39");
+            WriteWiimoteMapping("14", "45");
+            WriteWiimoteMapping("15", "44");
+            WriteWiimoteMapping("16", "38");
+
             writer.WriteEndElement();//end of mappings
             writer.WriteEndElement();//end of controller
             writer.WriteEndElement();//end of emulated_controller

--- a/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
+++ b/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
@@ -2578,6 +2578,7 @@ namespace emulatorLauncher.libRetro
             // Controls
             BindFeature(retroarchConfig, "input_libretro_device_p1", "mesen_controller1", "1");
             BindFeature(retroarchConfig, "input_libretro_device_p2", "mesen_controller2", "1");
+            BindFeature(retroarchConfig, "input_overlay_show_mouse_cursor", "ShowCursor", "false");
 
             SetupLightGuns(retroarchConfig, "262", 2);
         }


### PR DESCRIPTION
**Add controller choice for player 1 & player 2:**
Some games do not accept 2 gamepads in multiplayer (e.g. mario kart). Other games accept ONLY pro controllers in multiplayer (e.g. New super mario wiiu)

**Add wiimotes feature**
Possibility to use wiimotes in CEMU, however as wiimotes are not recognized in ES, it's either wiimotes or gamepad configuration.
If user sets wiimotes ==> all controllers will be set to real wiimotes.
Same principle as Dolphin.