### PR TITLE
Cheats path harmonization, pcsx_rearmed game fixes feature and MAME64 stuff

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -6685,6 +6685,11 @@
       <choice name="XINPUT" value="xinput"/>
       <choice name="DINPUT" value="dinput"/>
     </feature>
+    <feature submenu="CONTROLS" name="CONTROLLER PROFILE" group="ADVANCED SETTINGS" value="mame_ctrlr_profile" description="The RetroBat team has prepared profiles for some common controllers, they are located in 'saves\mame\ctrlr' folder.">
+      <choice name="NONE" value="none"/>
+      <choice name="SONY DS4" value="ds4_ds5"/>
+      <choice name="SONY DS5 (DUALSENSE)" value="ds4_ds5"/>
+    </feature>
     <feature submenu="CONTROLS" name="LIGHTGUN DEVICE" group="ADVANCED SETTINGS" value="mame_lightgun">
       <choice name="NONE" value="none"/>
       <choice name="MOUSE" value="mouse"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -2910,6 +2910,17 @@
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>
       </feature>
+      <feature submenu="EMULATION" name="GAME FIXES" group="ADVANCED SETTINGS" value="pcsx_game_fixes" description="Apply fix for some games.">
+        <choice name="Off" value="disabled"/>
+        <choice name="Capcom VS games Expand Screen Width" value="pcsx_rearmed_gpu_peops_expand_screen_width"/>
+        <choice name="Chrono Chross Odd/Even Bit Hack" value="pcsx_rearmed_gpu_peops_odd_even_bit"/>
+        <choice name="Dark Forces Flat Tex Triangles Fix" value="pcsx_rearmed_gpu_peops_repeated_triangles"/>
+        <choice name="Diablo Music Fix" value="pcsx_rearmed_idiablofix"/>
+        <choice name="Lunar Ignore Brightness Color Fix" value="pcsx_rearmed_gpu_peops_ignore_brightness"/>
+        <choice name="InuYasha Sengoku Battle Fix" value="pcsx_rearmed_inuyasha_fix"/>
+        <choice name="Pandemonium 2 Lazy Screen Update Fix" value="pcsx_rearmed_gpu_peops_lazy_screen_update"/>
+        <choice name="Parasite Eve 2/Vandal Hearts 1 and 2 Fix" value="pcsx_rearmed_pe2_fix"/>
+      </feature>
       <feature submenu="USER INTERFACE" name="DISPLAY FPS" value="display_internal_fps" group="ADVANCED SETTINGS" description="Show FPS overlay in-game.">
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -6685,10 +6685,14 @@
       <choice name="XINPUT" value="xinput"/>
       <choice name="DINPUT" value="dinput"/>
     </feature>
-    <feature submenu="CONTROLS" name="CONTROLLER PROFILE" group="ADVANCED SETTINGS" value="mame_ctrlr_profile" description="The RetroBat team has prepared profiles for some common controllers, they are located in 'saves\mame\ctrlr' folder.">
+    <feature submenu="CONTROLS" name="CONTROLLER PROFILE" group="ADVANCED SETTINGS" value="mame_ctrlr_profile" description="The RetroBat team has prepared profiles for some common controllers, they are located in 'saves\mame\ctrlr' folder. CUSTOM can be used for saving one's own mappings.">
       <choice name="NONE" value="none"/>
       <choice name="SONY DS4" value="ds4_ds5"/>
       <choice name="SONY DS5 (DUALSENSE)" value="ds4_ds5"/>
+      <choice name="CUSTOM 1" value="custom1"/>
+      <choice name="CUSTOM 2" value="custom2"/>
+      <choice name="CUSTOM 3" value="custom3"/>
+      <choice name="CUSTOM 4" value="custom4"/>
     </feature>
     <feature submenu="CONTROLS" name="LIGHTGUN DEVICE" group="ADVANCED SETTINGS" value="mame_lightgun">
       <choice name="NONE" value="none"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -6617,7 +6617,6 @@
       <choice name="YES" value="1"/>
       <choice name="NO" value="0"/>
     </feature>
-    <sharedFeature group="ADVANCED SETTINGS" value="videomode"/>
     <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="MonitorIndex"/>
     <feature submenu="VIDEO" name="TRIPLE BUFFERING" group="ADVANCED SETTINGS" value="triplebuffer">
       <choice name="NO" value="0"/>
@@ -6664,6 +6663,10 @@
       <choice name="YES" value="1"/>
     </feature>
     <feature submenu="EMULATION" name="ENABLE HISCORES" group="ADVANCED SETTINGS" value="mame_hiscore" description="Saves the hiscores in supported games.">
+      <choice name="NO" value="0"/>
+      <choice name="YES" value="1"/>
+    </feature>
+    <feature submenu="EMULATION" name="DISABLE THROTTLE" group="ADVANCED SETTINGS" value="mame_throttle" description="When throttling is disabled, MAME runs the emulation as fast as possible.">
       <choice name="NO" value="0"/>
       <choice name="YES" value="1"/>
     </feature>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -8106,6 +8106,10 @@
       <choice name="简体中文 (Chinese)" value="8"/>
       <choice name="Português" value="9"/>
     </feature>
+    <feature submenu="EMULATION" name="SKIP BOOT" group="ADVANCED SETTINGS" value="show_boot" description="Default is on, disable to show XBOX boot animation.">
+      <choice name="YES" value="0"/>
+      <choice name="NO" value="1"/>
+    </feature>
   </emulator>
   <!-- XENIA -->
   <emulator name="xenia, xenia-canary">

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -6690,6 +6690,10 @@
       <choice name="MOUSE" value="mouse"/>
       <choice name="LIGHTGUN" value="lightgun"/>
     </feature>
+    <feature submenu="CONTROLS" name="ENABLE MOUSE" group="ADVANCED SETTINGS" value="mame_mouse" description="Enable mouse input for trackballs, spinners, and similar controls.">
+      <choice name="NO" value="0"/>
+      <choice name="YES" value="1"/>
+    </feature>
     <feature submenu="CONTROLS" name="GUN RELOAD WITH BUTTON" group="ADVANCED SETTINGS" value="mame_offscreen_reload" description="Turn this on when using a lightgun that does not support offscreen reload.">
       <choice name="NO" value="0"/>
       <choice name="YES" value="1"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -6577,6 +6577,42 @@
     <sharedFeature group="ADVANCED SETTINGS" value="videomode"/>
   </emulator>
   <emulator name="mame64">
+    <feature name="INTERNAL RESOLUTION" group="GENERAL SETTINGS" value="internal_resolution">
+      <choice name="640x480" value="640x480"/>
+      <choice name="640x360" value="640x360"/>
+      <choice name="960x720" value="960x720"/>
+      <choice name="960x540" value="960x540"/>
+      <choice name="1280x960" value="1280x960"/>
+      <choice name="1280x720" value="1280x720"/>
+      <choice name="1440x1080" value="1440x1080"/>
+      <choice name="1920x1080" value="1920x1080"/>
+      <choice name="1920x1440" value="1920x1440"/>
+      <choice name="2560x1440" value="2560x1440"/>
+      <choice name="2880x2160" value="2880x2160"/>
+      <choice name="3840x2160" value="3840x2160"/>
+    </feature>
+    <feature name="GAME ASPECT RATIO" group="GENERAL SETTINGS" value="ratio">
+      <choice name="4/3" value="4:3"/>
+      <choice name="16/9" value="16:9"/>
+      <choice name="16/10" value="16:10"/>
+      <choice name="16/15" value="16:15"/>
+      <choice name="21/9" value="21:9"/>
+      <choice name="1/1" value="1:1"/>
+      <choice name="2/1" value="2:1"/>
+      <choice name="3/2" value="3:2"/>
+      <choice name="3/4" value="3:4"/>
+      <choice name="4/1" value="4:1"/>
+      <choice name="9/16" value="9:16"/>
+      <choice name="5/4" value="5:4"/>
+      <choice name="6/5" value="6:5"/>
+      <choice name="7/9" value="7:9"/>
+      <choice name="8/3" value="8:3"/>
+      <choice name="8/7" value="8:7"/>
+      <choice name="19/12" value="19:12"/>
+      <choice name="19/14" value="19:14"/>
+      <choice name="30/17" value="30:17"/>
+      <choice name="32/9" value="32:9"/>
+    </feature>
     <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="vsync">
       <choice name="YES" value="1"/>
       <choice name="NO" value="0"/>
@@ -6612,6 +6648,17 @@
       <choice name="FIGHTERS" value="Fighters"/>
       <choice name="HLSL" value="hlsl"/>
     </feature>
+    <feature submenu="VISUAL RENDERING" name="EFFECT" group="ADVANCED SETTINGS" value="effect" description="Select effect to apply.">
+      <choice name="SCANLINES" value="scanlines"/>
+      <choice name="APERTURE" value="aperture"/>
+      <choice name="APERTURE GRID" value="aperture-grille"/>
+      <choice name="MONOCHROME MATRIX" value="monochrome-matrix"/>
+      <choice name="SHADOW MASK" value="shadow-mask"/>
+      <choice name="SLOT MASK" value="slot-mask"/>
+      <choice name="SLOT MASK ALIGNED" value="slot-mask-aligned"/>
+    </feature>
+    <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
+    <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
     <feature submenu="EMULATION" name="ENABLE CHEATS" group="ADVANCED SETTINGS" value="mame_cheats" description="Cheats need to be placed in 'bios\mame' folder.">
       <choice name="NO" value="0"/>
       <choice name="YES" value="1"/>
@@ -6625,6 +6672,11 @@
       <choice name="OPENGL" value="opengl"/>
       <choice name="BGFX" value="bgfx"/>
       <choice name="GDI" value="gdi"/>
+    </feature>
+    <feature submenu="DRIVERS" name="AUDIO" group="ADVANCED SETTINGS" value="mame_audio_driver">
+      <choice name="DIRECTSOUND" value="dsound"/>
+      <choice name="XAUDIO2" value="xaudio2"/>
+      <choice name="PORTAUDIO" value="portaudio"/>
     </feature>
     <feature submenu="DRIVERS" name="CONTROLLER" group="ADVANCED SETTINGS" value="mame_joystick_driver">
       <choice name="XINPUT" value="xinput"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -6582,6 +6582,7 @@
       <choice name="NO" value="0"/>
     </feature>
     <sharedFeature group="ADVANCED SETTINGS" value="videomode"/>
+    <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="MonitorIndex"/>
     <feature submenu="VIDEO" name="TRIPLE BUFFERING" group="ADVANCED SETTINGS" value="triplebuffer">
       <choice name="NO" value="0"/>
       <choice name="YES" value="1"/>
@@ -6590,6 +6591,26 @@
       <choice name="NO" value="off"/>
       <choice name="CLOCKWISE" value="autoror"/>
       <choice name="COUNTER-CLOCKWISE" value="autorol"/>
+    </feature>
+    <feature submenu="VISUAL RENDERING" name="SHADER VIDEO DRIVER" group="ADVANCED SETTINGS" value="bgfxbackend" description="Select the driver used for shaders (BGFX), shaders are only available with the bgfx video driver.">
+      <choice name="VULKAN" value="vulkan"/>
+      <choice name="OPENGL" value="opengl"/>
+      <choice name="DIRECT3D 12" value="d3d12"/>
+      <choice name="DIRECT3D 11" value="d3d11"/>
+      <choice name="DIRECT3D 9" value="d3d9"/>
+    </feature>
+    <feature submenu="VISUAL RENDERING" name="BGFX VIDEO FILTER" group="ADVANCED SETTINGS" value="bgfxshaders" description="Select shader to apply, only compatible with 'bgfx' video driver.">
+      <choice name="DEFAULT BILINEAR FILTERED OUTPUT" value="default"/>
+      <choice name="NEAREST NEIGHBOR SAMPLED OUTPUT" value="unfiltered"/>
+      <choice name="CRT SIMULATION" value="crt-geom-deluxe"/>
+      <choice name="LIGHTWEIGHT CRT SIMULATION" value="crt-geom"/>
+      <choice name="LCD MATRIX SIMULATION" value="lcd-grid"/>
+      <choice name="HQ2X" value="hq2x"/>
+      <choice name="HQ3X" value="hq3x"/>
+      <choice name="HQ4X" value="hq4x"/>
+      <choice name="SUPER EAGLE" value="super-eagle"/>
+      <choice name="FIGHTERS" value="Fighters"/>
+      <choice name="HLSL" value="hlsl"/>
     </feature>
     <feature submenu="EMULATION" name="ENABLE CHEATS" group="ADVANCED SETTINGS" value="mame_cheats" description="Cheats need to be placed in 'bios\mame' folder.">
       <choice name="NO" value="0"/>

--- a/emulatorLauncher/Common/ConfigFile.cs
+++ b/emulatorLauncher/Common/ConfigFile.cs
@@ -126,7 +126,7 @@ namespace emulatorLauncher
                 if (key == "home" && Directory.Exists(Path.Combine(LocalPath, ".emulationstation")))                        
                     return Path.Combine(LocalPath, ".emulationstation");
 
-                if (key == "bios" || key == "saves" || key == "thumbnails" || key == "shaders" || key == "decorations" || key == "screenshots" || key == "roms" || key == "records")
+                if (key == "bios" || key == "saves" || key == "thumbnails" || key == "shaders" || key == "decorations" || key == "screenshots" || key == "roms" || key == "records" || key == "cheats")
                 {
                     if (Directory.Exists(Path.GetFullPath(Path.Combine(LocalPath, "..", key))))
                         return Path.Combine(Path.GetFullPath(Path.Combine(LocalPath, "..", key)));

--- a/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
+++ b/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
@@ -2627,6 +2627,23 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "pcsx_rearmed_spu_interpolation", "pcsx_rearmed_spu_interpolation", "simple");
             BindFeature(coreSettings, "pcsx_rearmed_icache_emulation", "pcsx_rearmed_icache_emulation", "disabled");
 
+            // Game fixes
+
+            coreSettings["pcsx_rearmed_idiablofix"] = "disabled";
+            coreSettings["pcsx_rearmed_pe2_fix"] = "disabled";
+            coreSettings["pcsx_rearmed_inuyasha_fix"] = "disabled";
+            coreSettings["pcsx_rearmed_gpu_peops_odd_even_bit"] = "disabled";
+            coreSettings["pcsx_rearmed_gpu_peops_expand_screen_width"] = "disabled";
+            coreSettings["pcsx_rearmed_gpu_peops_ignore_brightness"] = "disabled";
+            coreSettings["pcsx_rearmed_gpu_peops_lazy_screen_update"] = "disabled";
+            coreSettings["pcsx_rearmed_gpu_peops_repeated_triangles"] = "disabled";
+            
+            if (SystemConfig.isOptSet("pcsx_game_fixes") && SystemConfig["pcsx_game_fixes"] != "disabled")
+            {
+                var patchValue = SystemConfig["pcsx_game_fixes"];
+                coreSettings[patchValue] = "enabled";
+            }
+
             // Controls
             BindFeature(coreSettings, "pcsx_rearmed_vibration", "pcsx_rearmed_vibration", "disabled");
             BindFeature(retroarchConfig, "input_libretro_device_p1", "psx_controller1", "259");

--- a/emulatorLauncher/Generators/LibRetro.Generator.cs
+++ b/emulatorLauncher/Generators/LibRetro.Generator.cs
@@ -136,6 +136,15 @@ namespace emulatorLauncher.libRetro
                     retroarchConfig["screenshot_directory"] = @":\screenshots";
             }
 
+            // Cheats folder
+            if (!string.IsNullOrEmpty(AppConfig["cheats"]))
+            {
+                if (Directory.Exists(AppConfig["cheats"]))
+                    retroarchConfig["cheat_database_path"] = AppConfig.GetFullPath("cheats");
+                else if (retroarchConfig["cheat_database_path"] != @":\cheats" && !Directory.Exists(retroarchConfig["cheat_database_path"]))
+                    retroarchConfig["cheat_database_path"] = @":\cheats";
+            }
+
             // Records path
             string recordconfigpath = Path.Combine(AppConfig.GetFullPath("records"), "config");
             if (!string.IsNullOrEmpty(recordconfigpath))

--- a/emulatorLauncher/Generators/LibRetro.Generator.cs
+++ b/emulatorLauncher/Generators/LibRetro.Generator.cs
@@ -1153,7 +1153,7 @@ namespace emulatorLauncher.libRetro
             MessSystem messSystem = core == "mame" ? MessSystem.GetMessSystem(system, subCore) : null;
             if (messSystem != null && !string.IsNullOrEmpty(messSystem.MachineName))
             {
-                var messArgs = messSystem.GetMameCommandLineArguments(system, rom);
+                var messArgs = messSystem.GetMameCommandLineArguments(system, rom, emulator);
                 messArgs = messArgs.Replace("\\\"", "\"");
                 messArgs = "\"" + messArgs.Replace("\"", "\\\"") + "\"";
                 messArgs = (messArgs + " " + args).Trim();

--- a/emulatorLauncher/Generators/LibRetro.Generator.cs
+++ b/emulatorLauncher/Generators/LibRetro.Generator.cs
@@ -137,10 +137,11 @@ namespace emulatorLauncher.libRetro
             }
 
             // Cheats folder
-            if (!string.IsNullOrEmpty(AppConfig["cheats"]))
+            string cheatspath = Path.Combine(AppConfig.GetFullPath("cheats"), "retroarch");
+            if (!string.IsNullOrEmpty(cheatspath))
             {
-                if (Directory.Exists(AppConfig["cheats"]))
-                    retroarchConfig["cheat_database_path"] = AppConfig.GetFullPath("cheats");
+                if (Directory.Exists(cheatspath))
+                    retroarchConfig["cheat_database_path"] = cheatspath;
                 else if (retroarchConfig["cheat_database_path"] != @":\cheats" && !Directory.Exists(retroarchConfig["cheat_database_path"]))
                     retroarchConfig["cheat_database_path"] = @":\cheats";
             }

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -74,7 +74,7 @@ namespace emulatorLauncher
                 // Cheats
                 if (SystemConfig.isOptSet("mame_cheats") && SystemConfig.getOptBoolean("mame_cheats"))
                 {
-                    string cheatPath = Path.Combine(AppConfig.GetFullPath("bios"), "mame");
+                    string cheatPath = Path.Combine(AppConfig.GetFullPath("cheats"), "mame");
                     if (!string.IsNullOrEmpty(cheatPath) && Directory.Exists(cheatPath))
                     {
                         commandArray.Add("-cheat");

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -154,6 +154,7 @@ namespace emulatorLauncher
                 /// -crosshairpath
                 /// -swpath
 
+                // Video settings
                 commandArray.Add("-video");
                 if (SystemConfig.isOptSet("mame_video_driver") && SystemConfig.isOptSet("mame_video_driver"))
                     commandArray.Add(SystemConfig["mame_video_driver"]);
@@ -168,6 +169,30 @@ namespace emulatorLauncher
 
                 if (SystemConfig.isOptSet("mame_rotate") && SystemConfig["mame_rotate"] != "off")
                     commandArray.Add("-" + SystemConfig["mame_rotate"]);
+
+                if (SystemConfig.isOptSet("MonitorIndex") && !string.IsNullOrEmpty(SystemConfig["MonitorIndex"]))
+                {
+                    string mameMonitor = "\\" + "\\" + ".\\" + "DISPLAY" + SystemConfig["MonitorIndex"];
+                    commandArray.Add("-screen");
+                    commandArray.Add(mameMonitor);
+                }
+
+                if (SystemConfig.isOptSet("bgfxbackend") && (SystemConfig["mame_video_driver"] == "bgfx") && !string.IsNullOrEmpty(SystemConfig["bgfxbackend"]))
+                {
+                    commandArray.Add("-bgfx_backend");
+                    commandArray.Add(SystemConfig["bgfxbackend"]);
+
+                    if (SystemConfig.isOptSet("bgfxshaders") && !string.IsNullOrEmpty(SystemConfig["bgfxshaders"]))
+                    {
+                        commandArray.Add("-bgfx_screen_chains");
+                        commandArray.Add(SystemConfig["bgfxshaders"]);
+                    }
+                    else if (Features.IsSupported("bgfxshaders"))
+                    {
+                        commandArray.Add("-bgfx_screen_chains");
+                        commandArray.Add("default");
+                    }
+                }
 
                 // Add plugins
                 List<string> pluginList = new List<string>();

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -182,6 +182,8 @@ namespace emulatorLauncher
         {
             var retList = new List<string>();
 
+            retList.Add("-verbose");
+
             // Throttle
             if (Program.SystemConfig.isOptSet("mame_throttle") && Program.SystemConfig.getOptBoolean("mame_throttle"))
                 retList.Add("-nothrottle");
@@ -294,21 +296,63 @@ namespace emulatorLauncher
             // Enable inputs
             if (Program.SystemConfig.isOptSet("mame_lightgun") && !string.IsNullOrEmpty(Program.SystemConfig["mame_lightgun"]))
             {
-                if (Program.SystemConfig["mame_lightgun"] == "none")
+                if (Program.SystemConfig["mame_lightgun"] == "mouse")
                 {
                     retList.Add("-lightgun_device");
-                    retList.Add("none");
+                    retList.Add("mouse");
+                    retList.Add("-adstick_device");
+                    retList.Add("mouse");
                 }
                 else if (Program.SystemConfig["mame_lightgun"] == "lightgun")
                 {
                     retList.Add("-lightgun_device");
                     retList.Add("lightgun");
+                    retList.Add("-adstick_device");
+                    retList.Add("lightgun");
+                }
+                else if (Program.SystemConfig["mame_lightgun"] == "none")
+                {
+                    retList.Add("-lightgun_device");
+                    retList.Add("none");
+                    retList.Add("-adstick_device");
+                    retList.Add("none");
                 }
                 else
                 {
                     retList.Add("-lightgun_device");
-                    retList.Add("mouse");
+                    retList.Add("joystick");
+                    retList.Add("-adstick_device");
+                    retList.Add("joystick");
                 }
+            }
+
+            // Other devices
+            if (Program.SystemConfig.isOptSet("mame_mouse") && Program.SystemConfig.getOptBoolean("mame_mouse"))
+            {
+                retList.Add("-dial_device");
+                retList.Add("mouse");
+                retList.Add("-trackball_device");
+                retList.Add("mouse");
+                retList.Add("-paddle_device");
+                retList.Add("mouse");
+                retList.Add("-positional_device");
+                retList.Add("mouse");
+                retList.Add("-mouse_device");
+                retList.Add("mouse");
+                retList.Add("-ui_mouse");
+            }
+            else
+            {
+                retList.Add("-dial_device");
+                retList.Add("joystick");
+                retList.Add("-trackball_device");
+                retList.Add("joystick");
+                retList.Add("-paddle_device");
+                retList.Add("joystick");
+                retList.Add("-positional_device");
+                retList.Add("joystick");
+                retList.Add("-mouse_device");
+                retList.Add("joystick");
             }
 
             if (Program.SystemConfig.isOptSet("mame_offscreen_reload") && Program.SystemConfig.getOptBoolean("mame_offscreen_reload") && Program.SystemConfig["mame_lightgun"] != "none")

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -365,6 +365,15 @@ namespace emulatorLauncher
             else
                 retList.Add("winhybrid");
 
+            if (Program.SystemConfig.isOptSet("mame_ctrlr_profile") && Program.SystemConfig["mame_ctrlr_profile"] != "none")
+            {
+                string ctrlrProfile = Path.Combine(Program.AppConfig.GetFullPath("saves"), "mame", "ctrlr", Program.SystemConfig["mame_ctrlr_profile"] + ".cfg");
+                if (File.Exists(ctrlrProfile))
+                {
+                    retList.Add("-ctrlr");
+                    retList.Add(Program.SystemConfig["mame_ctrlr_profile"]);
+                }
+            }
             return retList;
         }
 

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -182,6 +182,12 @@ namespace emulatorLauncher
         {
             var retList = new List<string>();
 
+            // Throttle
+            if (Program.SystemConfig.isOptSet("mame_throttle") && Program.SystemConfig.getOptBoolean("mame_throttle"))
+                retList.Add("-nothrottle");
+            else
+                retList.Add("-throttle");
+
             // Autosave and rewind
             if (Program.SystemConfig.isOptSet("autosave") && Program.SystemConfig.getOptBoolean("autosave"))
                 retList.Add("-autosave");

--- a/emulatorLauncher/Generators/MessSystem.cs
+++ b/emulatorLauncher/Generators/MessSystem.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.IO;
+using emulatorLauncher;
+using emulatorLauncher.Tools;
 
 namespace emulatorLauncher
 {
@@ -516,7 +518,7 @@ namespace emulatorLauncher
             return path;
         }
 
-        public string GetMameCommandLineArguments(string system, string rom, bool injectCfgDirectory = true)
+        public string GetMameCommandLineArguments(string system, string rom, string emulator, bool injectCfgDirectory = true)
         {
             List<string> commandArray = new List<string>();
 
@@ -585,6 +587,32 @@ namespace emulatorLauncher
             {
                 commandArray.Add("-snapshot_directory");
                 commandArray.Add(AppConfig.GetFullPath("screenshots"));
+            }
+
+            // Additional paths for mame standalone
+            if (emulator == "mame64")
+            {
+                string sstatePath = Path.Combine(AppConfig.GetFullPath("saves"), "mame", "states");
+                if (!Directory.Exists(sstatePath)) try { Directory.CreateDirectory(sstatePath); }
+                    catch { }
+                if (!string.IsNullOrEmpty(sstatePath) && Directory.Exists(sstatePath))
+                {
+                    commandArray.Add("-state_directory");
+                    commandArray.Add(sstatePath);
+                }
+
+                string ctrlrPath = Path.Combine(AppConfig.GetFullPath("saves"), "mame", "ctrlr");
+                if (!Directory.Exists(ctrlrPath)) try { Directory.CreateDirectory(ctrlrPath); }
+                    catch { }
+                if (!string.IsNullOrEmpty(ctrlrPath) && Directory.Exists(ctrlrPath))
+                {
+                    commandArray.Add("-ctrlrpath");
+                    commandArray.Add(ctrlrPath);
+                }
+
+                List<string> arguments = Mame64Generator.mameArguments();
+                if (arguments.Count != 0)
+                    commandArray.AddRange(arguments);
             }
 
             // Autostart computer games where applicable

--- a/emulatorLauncher/Generators/MessSystem.cs
+++ b/emulatorLauncher/Generators/MessSystem.cs
@@ -586,7 +586,7 @@ namespace emulatorLauncher
                 commandArray.Add("-snapshot_directory");
                 commandArray.Add(AppConfig.GetFullPath("screenshots"));
             }
-             
+
             // Autostart computer games where applicable
             // Generic boot if only one type is available
             var autoRunCommand = SystemConfig.isOptSet("altromtype") ? GetAutoBootForRomType(SystemConfig["altromtype"]) : GetAutoBoot(rom);

--- a/emulatorLauncher/Generators/Pcsx2.Generator.cs
+++ b/emulatorLauncher/Generators/Pcsx2.Generator.cs
@@ -691,15 +691,27 @@ namespace emulatorLauncher
 
                 // Cheats Path
                 string cheatsPath = AppConfig.GetFullPath("cheats");
-                string cheatsPcsx2Path = Path.Combine(cheatsPath, "pcsx2");
 
-                if (!Directory.Exists(cheatsPcsx2Path))
-                    try { Directory.CreateDirectory(cheatsPcsx2Path); }
-                    catch { }
+                if (string.IsNullOrEmpty(cheatsPath))
+                {
+                    cheatsPath = Path.GetFullPath(Path.Combine("home", "..", "..", "cheats"));
+                    if (!Directory.Exists(cheatsPath))
+                        try { Directory.CreateDirectory(cheatsPath); }
+                        catch { }
+                }
 
-                ini.WriteValue("Folders", "Cheats", Path.Combine(cheatsPcsx2Path, "cheats"));
-                ini.WriteValue("Folders", "CheatsWS", Path.Combine(cheatsPcsx2Path, "cheats_ws"));
-                ini.WriteValue("Folders", "CheatsNI", Path.Combine(cheatsPcsx2Path, "cheats_ni"));
+                if (!string.IsNullOrEmpty(cheatsPath))
+                {
+                    string cheatsPcsx2Path = Path.Combine(cheatsPath, "pcsx2");
+
+                    if (!Directory.Exists(cheatsPcsx2Path))
+                        try { Directory.CreateDirectory(cheatsPcsx2Path); }
+                        catch { }
+
+                    ini.WriteValue("Folders", "Cheats", Path.Combine(cheatsPcsx2Path, "cheats"));
+                    ini.WriteValue("Folders", "CheatsWS", Path.Combine(cheatsPcsx2Path, "cheats_ws"));
+                    ini.WriteValue("Folders", "CheatsNI", Path.Combine(cheatsPcsx2Path, "cheats_ni"));
+                }
 
                 //precise bios to use
 

--- a/emulatorLauncher/Generators/Pcsx2.Generator.cs
+++ b/emulatorLauncher/Generators/Pcsx2.Generator.cs
@@ -155,6 +155,7 @@ namespace emulatorLauncher
                 using (var ini = new IniFile(iniFile))
                 {
                     string biosPath = AppConfig.GetFullPath("bios");
+                    string cheatsPath = AppConfig.GetFullPath("cheats");
                     if (!string.IsNullOrEmpty(biosPath))
                     {
                         ini.WriteValue("Folders", "UseDefaultBios", "disabled");
@@ -165,9 +166,9 @@ namespace emulatorLauncher
                             ini.WriteValue("Folders", "Bios", biosPath.Replace("\\", "\\\\"));
 
                         ini.WriteValue("Folders", "UseDefaultCheats", "disabled");
-                        ini.WriteValue("Folders", "Cheats", Path.Combine(biosPath, "pcsx2", "cheats").Replace("\\", "\\\\"));
+                        ini.WriteValue("Folders", "Cheats", Path.Combine(cheatsPath, "pcsx2", "cheats").Replace("\\", "\\\\"));
                         ini.WriteValue("Folders", "UseDefaultCheatsWS", "disabled");
-                        ini.WriteValue("Folders", "CheatsWS", Path.Combine(biosPath, "pcsx2", "cheats_ws").Replace("\\", "\\\\"));
+                        ini.WriteValue("Folders", "CheatsWS", Path.Combine(cheatsPath, "pcsx2", "cheats_ws").Replace("\\", "\\\\"));
                     }
 
                     string savesPath = AppConfig.GetFullPath("saves");
@@ -688,9 +689,17 @@ namespace emulatorLauncher
                     try { Directory.CreateDirectory(biosPcsx2Path); }
                     catch { }
 
-                ini.WriteValue("Folders", "Cheats", Path.Combine(biosPcsx2Path, "cheats"));
-                ini.WriteValue("Folders", "CheatsWS", Path.Combine(biosPcsx2Path, "cheats_ws"));
-                ini.WriteValue("Folders", "CheatsNI", Path.Combine(biosPcsx2Path, "cheats_ni"));
+                // Cheats Path
+                string cheatsPath = AppConfig.GetFullPath("cheats");
+                string cheatsPcsx2Path = Path.Combine(cheatsPath, "pcsx2");
+
+                if (!Directory.Exists(cheatsPcsx2Path))
+                    try { Directory.CreateDirectory(cheatsPcsx2Path); }
+                    catch { }
+
+                ini.WriteValue("Folders", "Cheats", Path.Combine(cheatsPcsx2Path, "cheats"));
+                ini.WriteValue("Folders", "CheatsWS", Path.Combine(cheatsPcsx2Path, "cheats_ws"));
+                ini.WriteValue("Folders", "CheatsNI", Path.Combine(cheatsPcsx2Path, "cheats_ni"));
 
                 //precise bios to use
 

--- a/emulatorLauncher/Generators/Xemu.Generator.cs
+++ b/emulatorLauncher/Generators/Xemu.Generator.cs
@@ -144,8 +144,13 @@ namespace emulatorLauncher
             {
                 // Force settings
                 ini.WriteValue("general", "show_welcome", "false");
-                ini.WriteValue("general", "skip_boot_anim", "true");
                 ini.WriteValue("general.updates", "check", "false");
+
+                // Skip Boot anim
+                if (SystemConfig.isOptSet("show_boot") && SystemConfig.getOptBoolean("show_boot"))
+                    ini.WriteValue("general", "skip_boot_anim", "false");
+                else if (Features.IsSupported("show_boot"))
+                    ini.WriteValue("general", "skip_boot_anim", "true");
 
                 // Controllers
                 if (!SystemConfig.getOptBoolean("disableautocontrollers"))

--- a/emulatorLauncher/Generators/Yuzu.Controllers.cs
+++ b/emulatorLauncher/Generators/Yuzu.Controllers.cs
@@ -150,7 +150,7 @@ namespace emulatorLauncher
             if (!controller.IsXInputDevice)
             {
                 ini.WriteValue("Controls", player + "motionleft" + "\\default", "false");
-                ini.WriteValue("Controls", player + "motionleft", "\"" + "engine:sdl,motion:0,port:" + index + ", guid:" + yuzuGuid + "\"");
+                ini.WriteValue("Controls", player + "motionleft", "\"" + "engine:sdl,motion:0,port:" + index + ",guid:" + yuzuGuid + "\"");
                 ini.WriteValue("Controls", player + "motionright" + "\\default", "false");
                 ini.WriteValue("Controls", player + "motionright", "\"" + "engine:sdl,motion:0,port:" + index + ",guid:" + yuzuGuid + "\"");
             }


### PR DESCRIPTION
PCSX_REARMED:
- Added game fix features

CHEATS PATH
- Moved cheats path to RetroBat \cheats folder for RetroArch & PCSX2

MAME64
- Add commandline arguments also for MESS systems when using mame64
- Add bgfx shaders features
- Add other features

YUZU
- fixed motion not working (additional space)