### PR TITLE
MAME64 & PCSX2 stuff

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -6689,6 +6689,7 @@
       <choice name="NONE" value="none"/>
       <choice name="SONY DS4" value="ds4_ds5"/>
       <choice name="SONY DS5 (DUALSENSE)" value="ds4_ds5"/>
+      <choice name="GAME SPECIFIC" value="per_game"/>
       <choice name="CUSTOM 1" value="custom1"/>
       <choice name="CUSTOM 2" value="custom2"/>
       <choice name="CUSTOM 3" value="custom3"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -936,6 +936,10 @@
           <choice name="YES" value="enabled"/>
         </feature>
       </system>
+      <feature submenu="VISUAL RENDERING" name="FORCE TEXTURES FILTERING" group="ADVANCED SETTINGS" value="dolphin_force_texture_filtering" description="Filter all textures. Including any that the game explicitly sets as unfiltered. Disabled by default.">
+        <choice name="NO" value="disabled"/>
+        <choice name="YES" value="enabled"/>
+      </feature>
       <feature submenu="VISUAL RENDERING" name="CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="dolphin_load_custom_textures" description="Replace original textures with custom textures pack.">
         <choice name="NO" value="disabled"/>
         <choice name="YES" value="enabled"/>
@@ -6067,6 +6071,10 @@
         <choice name="MSAA" value="false"/>
         <choice name="SSAA" value="true"/>
       </feature>
+      <feature submenu="VISUAL RENDERING" name="FORCE TEXTURES FILTERING" group="ADVANCED SETTINGS" value="ForceFiltering" description="Filter all textures. Including any that the game explicitly sets as unfiltered. Disabled by default.">
+        <choice name="NO" value="False"/>
+        <choice name="YES" value="True"/>
+      </feature>
       <feature submenu="VISUAL RENDERING" name="CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="hires_textures" description="Replace original textures with custom textures pack.">
         <choice name="NO" value="0"/>
         <choice name="YES" value="1"/>
@@ -6120,10 +6128,6 @@
       <feature submenu="EMULATION" name="SCALED EFB COPY (HACK)" group="ADVANCED SETTINGS" value="EFBScaledCopy" description="Greatly inscrease the quality of textures generated using render-to-texture effects. Enabled by default. Disabling it may avoid crashes for games using custom textures." order="89">
         <choice name="YES" value="True"/>
         <choice name="NO" value="False"/>
-      </feature>
-      <feature submenu="EMULATION" name="FORCE TEXTURES FILTERING" group="ADVANCED SETTINGS" value="ForceFiltering" description="Filter all textures. Including any that the game explicitly sets as unfiltered. Enabled by default." order="89">
-        <choice name="NO" value="False"/>
-        <choice name="YES" value="True"/>
       </feature>
       <feature submenu="EMULATION" name="PERFORMANCE MODE" group="ADVANCED SETTINGS" value="perf_hacks" description="Improves the emulation performance at the cost of accuracy." order="89">
         <choice name="NO" value="0"/>
@@ -6209,6 +6213,10 @@
         <choice name="MSAA" value="false"/>
         <choice name="SSAA" value="true"/>
       </feature>
+      <feature submenu="VISUAL RENDERING" name="FORCE TEXTURES FILTERING" group="ADVANCED SETTINGS" value="ForceFiltering" description="Filter all textures. Including any that the game explicitly sets as unfiltered. Disabled by default.">
+        <choice name="NO" value="False"/>
+        <choice name="YES" value="True"/>
+      </feature>
       <feature submenu="VISUAL RENDERING" name="CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="hires_textures" description="Replace original textures with custom textures pack.">
         <choice name="NO" value="0"/>
         <choice name="YES" value="1"/>
@@ -6259,10 +6267,6 @@
       <feature submenu="EMULATION" name="SCALED EFB COPY (HACK)" group="ADVANCED SETTINGS" value="EFBScaledCopy" description="Greatly inscrease the quality of textures generated using render-to-texture effects. Enabled by default. Disabling it may avoid crashes for games using custom textures.">
         <choice name="YES" value="True"/>
         <choice name="NO" value="False"/>
-      </feature>
-      <feature submenu="EMULATION" name="FORCE TEXTURES FILTERING" group="ADVANCED SETTINGS" value="ForceFiltering" description="Filter all textures. Including any that the game explicitly sets as unfiltered. Enabled by default.">
-        <choice name="NO" value="False"/>
-        <choice name="YES" value="True"/>
       </feature>
       <feature submenu="EMULATION" name="PERFORMANCE MODE" group="ADVANCED SETTINGS" value="perf_hacks" description="Improves the emulation performance at the cost of accuracy.">
         <choice name="NO" value="0"/>
@@ -6371,6 +6375,10 @@
       <choice name="MSAA" value="false"/>
       <choice name="SSAA" value="true"/>
     </feature>
+    <feature submenu="VISUAL RENDERING" name="FORCE TEXTURES FILTERING" group="ADVANCED SETTINGS" value="ForceFiltering" description="Filter all textures. Including any that the game explicitly sets as unfiltered. Disabled by default.">
+      <choice name="NO" value="False"/>
+      <choice name="YES" value="True"/>
+    </feature>
     <feature submenu="VISUAL RENDERING" name="CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="hires_textures" description="Replace original textures with custom textures pack.">
       <choice name="NO" value="0"/>
       <choice name="YES" value="1"/>
@@ -6424,10 +6432,6 @@
     <feature submenu="EMULATION" name="SCALED EFB COPY (HACK)" group="ADVANCED SETTINGS" value="EFBScaledCopy" description="Greatly inscrease the quality of textures generated using render-to-texture effects. Enabled by default. Disabling it may avoid crashes for games using custom textures.">
       <choice name="YES" value="True"/>
       <choice name="NO" value="False"/>
-    </feature>
-    <feature submenu="EMULATION" name="FORCE TEXTURES FILTERING" group="ADVANCED SETTINGS" value="ForceFiltering" description="Filter all textures. Including any that the game explicitly sets as unfiltered. Enabled by default.">
-      <choice name="NO" value="False"/>
-      <choice name="YES" value="True"/>
     </feature>
     <feature submenu="EMULATION" name="PERFORMANCE MODE" group="ADVANCED SETTINGS" value="perf_hacks" description="Improves the emulation performance at the cost of accuracy.">
       <choice name="NO" value="0"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -7080,7 +7080,7 @@
   </emulator>
   <!-- PCSX2 -->
   <emulator name="pcsx2" features="cheevos">
-    <core name="sse4, avx2" features="cheevos">
+    <core name="auto, sse4, avx2" features="cheevos">
       <feature name="SHADER SET" group="GENERAL SETTINGS" value="TVShader">
         <choice name="NO" value="0"/>
         <choice name="SCANLINES" value="1"/>
@@ -7153,9 +7153,10 @@
         <choice name="NO" value="false"/>
         <choice name="YES" value="true"/>
       </feature>
-      <feature submenu="VISUAL RENDERING" name="BILINEAR FILTERING" group="ADVANCED SETTINGS" value="bilinear_filtering" description="Use bilinear filtering when upscaling/downscaling the image to the screen.">
-        <choice name="YES" value="true"/>
-        <choice name="NO" value="false"/>
+      <feature submenu="VISUAL RENDERING" name="BILINEAR FILTERING" group="ADVANCED SETTINGS" value="bilinear_filtering" description="Use bilinear filtering to smooth the overall picture.">
+        <choice name="YES (SMOOTH)" value="1"/>
+        <choice name="YES (SHARP)" value="2"/>
+        <choice name="NO" value="0"/>
       </feature>
       <feature submenu="VISUAL RENDERING" name="TEXTURE FILTERING" group="ADVANCED SETTINGS" value="texture_filtering" description="Control the texture filtering of the emulation.">
         <choice name="NEAREST" value="0"/>

--- a/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
+++ b/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
@@ -654,6 +654,7 @@ namespace emulatorLauncher.libRetro
             BindFeature(coreSettings, "dolphin_enable_rumble", "dolphin_enable_rumble", "enabled");
             BindFeature(coreSettings, "dolphin_osd_enabled", "dolphin_osd_enabled", "disabled");
             BindFeature(coreSettings, "dolphin_cheats_enabled", "dolphin_cheats_enabled", "disabled");
+            BindFeature(coreSettings, "dolphin_force_texture_filtering", "dolphin_force_texture_filtering", "disabled");
 
             BindFeature(coreSettings, "dolphin_language", "dolphin_language", "English");
 

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -225,7 +225,7 @@ namespace emulatorLauncher
                     retList.Add("-switchres");
 
                 retList.Add("-resolution");
-                retList.Add(resolution.Width+"x"+resolution.Height);
+                retList.Add(resolution.Width+"x"+resolution.Height+"@"+resolution.DisplayFrequency);
             }
             else 
             {                

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -64,7 +64,7 @@ namespace emulatorLauncher
                 if (!string.IsNullOrEmpty(artPath) && Directory.Exists(artPath))
                 {
                     commandArray.Add("-artpath");
-                    commandArray.Add(artPath + ";" + Path.Combine(path, "artwork"));
+                    commandArray.Add(artPath + ";" + Path.Combine(path, "artwork") + ";" + Path.Combine(AppConfig.GetFullPath("saves"), "mame", "game_artwork"));
                 }
 
                 // Snapshots

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -64,7 +64,7 @@ namespace emulatorLauncher
                 if (!string.IsNullOrEmpty(artPath) && Directory.Exists(artPath))
                 {
                     commandArray.Add("-artpath");
-                    commandArray.Add(artPath + ";" + Path.Combine(path, "artwork") + ";" + Path.Combine(AppConfig.GetFullPath("saves"), "mame", "game_artwork"));
+                    commandArray.Add(artPath + ";" + Path.Combine(path, "artwork") + ";" + Path.Combine(AppConfig.GetFullPath("saves"), "mame", "artwork"));
                 }
 
                 // Snapshots

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -134,7 +134,7 @@ namespace emulatorLauncher
                 /// -crosshairpath
                 /// -swpath
 
-                commandArray.AddRange(GetCommonMame64Arguments(resolution));
+                commandArray.AddRange(GetCommonMame64Arguments(rom, resolution));
 
                 // Unknown system, try to run with rom name only
                 commandArray.Add(Path.GetFileName(rom));
@@ -144,7 +144,7 @@ namespace emulatorLauncher
             else
             {
                 var commandArray = messMode.GetMameCommandLineArguments(system, rom, true);
-                commandArray.AddRange(GetCommonMame64Arguments(resolution));
+                commandArray.AddRange(GetCommonMame64Arguments(rom, resolution));
 
                 args = commandArray.JoinArguments();
             }
@@ -164,7 +164,7 @@ namespace emulatorLauncher
             return PadToKey.AddOrUpdateKeyMapping(mapping, _exeName, InputKey.hotkey | InputKey.start, "(%{KILL})");
         }
 
-        private List<string> GetCommonMame64Arguments(ScreenResolution resolution = null)
+        private List<string> GetCommonMame64Arguments(string rom, ScreenResolution resolution = null)
         {
             var retList = new List<string>();
 

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -151,7 +151,7 @@ namespace emulatorLauncher
                 /// -crosshairpath
                 /// -swpath
 
-                List<string> arguments = mameArguments();
+                List<string> arguments = mameArguments(rom);
                 if (arguments.Count != 0)
                     commandArray.AddRange(arguments);
 
@@ -178,7 +178,7 @@ namespace emulatorLauncher
             return PadToKey.AddOrUpdateKeyMapping(mapping, _exeName, InputKey.hotkey | InputKey.start, "(%{KILL})");
         }
 
-        public static List<string> mameArguments()
+        public static List<string> mameArguments(string rom)
         {
             var retList = new List<string>();
 
@@ -368,10 +368,20 @@ namespace emulatorLauncher
             if (Program.SystemConfig.isOptSet("mame_ctrlr_profile") && Program.SystemConfig["mame_ctrlr_profile"] != "none")
             {
                 string ctrlrProfile = Path.Combine(Program.AppConfig.GetFullPath("saves"), "mame", "ctrlr", Program.SystemConfig["mame_ctrlr_profile"] + ".cfg");
-                if (File.Exists(ctrlrProfile))
+                if (File.Exists(ctrlrProfile) && Program.SystemConfig["mame_ctrlr_profile"] != "per_game")
                 {
                     retList.Add("-ctrlr");
                     retList.Add(Program.SystemConfig["mame_ctrlr_profile"]);
+                }
+                else if (Program.SystemConfig["mame_ctrlr_profile"] == "per_game")
+                {
+                    string romName = Path.GetFileNameWithoutExtension(rom);
+                    ctrlrProfile = Path.Combine(Program.AppConfig.GetFullPath("saves"), "mame", "ctrlr", romName + ".cfg");
+                    if (File.Exists(ctrlrProfile))
+                    {
+                        retList.Add("-ctrlr");
+                        retList.Add(romName);
+                    }
                 }
             }
             return retList;

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -186,42 +186,42 @@ namespace emulatorLauncher
                 retList.Add(ctrlrPath);
             }
 
-            if (!SystemConfig.isOptSet("smooth") || !Program.SystemConfig.getOptBoolean("smooth"))
+            if (!SystemConfig.isOptSet("smooth") || !SystemConfig.getOptBoolean("smooth"))
                 retList.Add("-nofilter");
 
             retList.Add("-verbose");
 
             // Throttle
-            if (Program.SystemConfig.isOptSet("mame_throttle") && Program.SystemConfig.getOptBoolean("mame_throttle"))
+            if (SystemConfig.isOptSet("mame_throttle") && SystemConfig.getOptBoolean("mame_throttle"))
                 retList.Add("-nothrottle");
             else
                 retList.Add("-throttle");
 
             // Autosave and rewind
-            if (Program.SystemConfig.isOptSet("autosave") && Program.SystemConfig.getOptBoolean("autosave"))
+            if (SystemConfig.isOptSet("autosave") && SystemConfig.getOptBoolean("autosave"))
                 retList.Add("-autosave");
 
-            if (Program.SystemConfig.isOptSet("rewind") && Program.SystemConfig.getOptBoolean("rewind"))
+            if (SystemConfig.isOptSet("rewind") && SystemConfig.getOptBoolean("rewind"))
                 retList.Add("-rewind");
 
             // Audio driver
             retList.Add("-sound");
-            if (Program.SystemConfig.isOptSet("mame_audio_driver") && !string.IsNullOrEmpty(Program.SystemConfig["mame_audio_driver"]))
-                retList.Add(Program.SystemConfig["mame_audio_driver"]);
+            if (SystemConfig.isOptSet("mame_audio_driver") && !string.IsNullOrEmpty(SystemConfig["mame_audio_driver"]))
+                retList.Add(SystemConfig["mame_audio_driver"]);
             else
                 retList.Add("dsound");
 
             // Video driver
             retList.Add("-video");
-            if (Program.SystemConfig.isOptSet("mame_video_driver") && !string.IsNullOrEmpty(Program.SystemConfig["mame_video_driver"]))
-                retList.Add(Program.SystemConfig["mame_video_driver"]);
+            if (SystemConfig.isOptSet("mame_video_driver") && !string.IsNullOrEmpty(SystemConfig["mame_video_driver"]))
+                retList.Add(SystemConfig["mame_video_driver"]);
             else
                 retList.Add("d3d");
 
             // Resolution
             if (resolution != null)
             {
-                if (Program.SystemConfig["mame_video_driver"] != "gdi" && Program.SystemConfig["mame_video_driver"] != "bgfx")
+                if (SystemConfig["mame_video_driver"] != "gdi" && SystemConfig["mame_video_driver"] != "bgfx")
                     retList.Add("-switchres");
 
                 retList.Add("-resolution");
@@ -235,59 +235,59 @@ namespace emulatorLauncher
 
             // Aspect ratio
             retList.Add("-aspect");
-            if (Program.SystemConfig.isOptSet("ratio") && !string.IsNullOrEmpty(Program.SystemConfig["ratio"]))
-                retList.Add(Program.SystemConfig["ratio"]);
+            if (SystemConfig.isOptSet("ratio") && !string.IsNullOrEmpty(SystemConfig["ratio"]))
+                retList.Add(SystemConfig["ratio"]);
             else
                 retList.Add("auto");
             
             // Monitor index
-            if (Program.SystemConfig.isOptSet("MonitorIndex") && !string.IsNullOrEmpty(Program.SystemConfig["MonitorIndex"]))
+            if (SystemConfig.isOptSet("MonitorIndex") && !string.IsNullOrEmpty(SystemConfig["MonitorIndex"]))
             {
-                string mameMonitor = "\\" + "\\" + ".\\" + "DISPLAY" + Program.SystemConfig["MonitorIndex"];
+                string mameMonitor = "\\" + "\\" + ".\\" + "DISPLAY" + SystemConfig["MonitorIndex"];
                 retList.Add("-screen");
                 retList.Add(mameMonitor);
             }
 
             // Screen rotation
-            if (Program.SystemConfig.isOptSet("mame_rotate") && Program.SystemConfig["mame_rotate"] != "off")
-                retList.Add("-" + Program.SystemConfig["mame_rotate"]);
+            if (SystemConfig.isOptSet("mame_rotate") && SystemConfig["mame_rotate"] != "off")
+                retList.Add("-" + SystemConfig["mame_rotate"]);
 
             // Other video options
-            if (Program.SystemConfig.isOptSet("triplebuffer") && Program.SystemConfig.getOptBoolean("triplebuffer") && Program.SystemConfig["mame_video_driver"] != "gdi")
+            if (SystemConfig.isOptSet("triplebuffer") && SystemConfig.getOptBoolean("triplebuffer") && SystemConfig["mame_video_driver"] != "gdi")
                 retList.Add("-triplebuffer");
 
-            if ((!Program.SystemConfig.isOptSet("vsync") || Program.SystemConfig.getOptBoolean("vsync")) && Program.SystemConfig["mame_video_driver"] != "gdi")
+            if ((!SystemConfig.isOptSet("vsync") || SystemConfig.getOptBoolean("vsync")) && SystemConfig["mame_video_driver"] != "gdi")
                 retList.Add("-waitvsync");
 
             // Shaders (only for bgfx driver)
-            if (Program.SystemConfig.isOptSet("bgfxbackend") && (Program.SystemConfig["mame_video_driver"] == "bgfx") && !string.IsNullOrEmpty(Program.SystemConfig["bgfxbackend"]))
+            if (SystemConfig.isOptSet("bgfxbackend") && (SystemConfig["mame_video_driver"] == "bgfx") && !string.IsNullOrEmpty(SystemConfig["bgfxbackend"]))
             {
                 retList.Add("-bgfx_backend");
-                retList.Add(Program.SystemConfig["bgfxbackend"]);
+                retList.Add(SystemConfig["bgfxbackend"]);
 
-                if (Program.SystemConfig.isOptSet("bgfxshaders") && !string.IsNullOrEmpty(Program.SystemConfig["bgfxshaders"]))
+                if (SystemConfig.isOptSet("bgfxshaders") && !string.IsNullOrEmpty(SystemConfig["bgfxshaders"]))
                 {
                     retList.Add("-bgfx_screen_chains");
-                    retList.Add(Program.SystemConfig["bgfxshaders"]);
+                    retList.Add(SystemConfig["bgfxshaders"]);
                 }
-                else if (Program.Features.IsSupported("bgfxshaders"))
+                else if (Features.IsSupported("bgfxshaders"))
                 {
                     retList.Add("-bgfx_screen_chains");
                     retList.Add("default");
                 }
             }
             
-            if (Program.SystemConfig.isOptSet("effect") && !string.IsNullOrEmpty(Program.SystemConfig["effect"]))
+            if (SystemConfig.isOptSet("effect") && !string.IsNullOrEmpty(SystemConfig["effect"]))
             {
                 retList.Add("-effect");
-                retList.Add(Program.SystemConfig["effect"]);
+                retList.Add(SystemConfig["effect"]);
             }
 
             // Add plugins
             List<string> pluginList = new List<string>();
-            if (Program.SystemConfig.isOptSet("mame_cheats") && Program.SystemConfig.getOptBoolean("mame_cheats"))
+            if (SystemConfig.isOptSet("mame_cheats") && SystemConfig.getOptBoolean("mame_cheats"))
                 pluginList.Add("cheat");
-            if (Program.SystemConfig.isOptSet("mame_hiscore") && Program.SystemConfig.getOptBoolean("mame_hiscore"))
+            if (SystemConfig.isOptSet("mame_hiscore") && SystemConfig.getOptBoolean("mame_hiscore"))
                 pluginList.Add("hiscore");
 
             if (pluginList.Count > 0)
@@ -298,23 +298,23 @@ namespace emulatorLauncher
             }
 
             // Enable inputs
-            if (Program.SystemConfig.isOptSet("mame_lightgun") && !string.IsNullOrEmpty(Program.SystemConfig["mame_lightgun"]))
+            if (SystemConfig.isOptSet("mame_lightgun") && !string.IsNullOrEmpty(SystemConfig["mame_lightgun"]))
             {
-                if (Program.SystemConfig["mame_lightgun"] == "mouse")
+                if (SystemConfig["mame_lightgun"] == "mouse")
                 {
                     retList.Add("-lightgun_device");
                     retList.Add("mouse");
                     retList.Add("-adstick_device");
                     retList.Add("mouse");
                 }
-                else if (Program.SystemConfig["mame_lightgun"] == "lightgun")
+                else if (SystemConfig["mame_lightgun"] == "lightgun")
                 {
                     retList.Add("-lightgun_device");
                     retList.Add("lightgun");
                     retList.Add("-adstick_device");
                     retList.Add("lightgun");
                 }
-                else if (Program.SystemConfig["mame_lightgun"] == "none")
+                else if (SystemConfig["mame_lightgun"] == "none")
                 {
                     retList.Add("-lightgun_device");
                     retList.Add("none");
@@ -331,7 +331,7 @@ namespace emulatorLauncher
             }
 
             // Other devices
-            if (Program.SystemConfig.isOptSet("mame_mouse") && Program.SystemConfig.getOptBoolean("mame_mouse"))
+            if (SystemConfig.isOptSet("mame_mouse") && SystemConfig.getOptBoolean("mame_mouse"))
             {
                 retList.Add("-dial_device");
                 retList.Add("mouse");
@@ -359,28 +359,28 @@ namespace emulatorLauncher
                 retList.Add("joystick");
             }
 
-            if (Program.SystemConfig.isOptSet("mame_offscreen_reload") && Program.SystemConfig.getOptBoolean("mame_offscreen_reload") && Program.SystemConfig["mame_lightgun"] != "none")
+            if (SystemConfig.isOptSet("mame_offscreen_reload") && SystemConfig.getOptBoolean("mame_offscreen_reload") && SystemConfig["mame_lightgun"] != "none")
                 retList.Add("-offscreen_reload");
 
             // Gamepad driver
             retList.Add("-joystickprovider");
-            if (Program.SystemConfig.isOptSet("mame_joystick_driver") && !string.IsNullOrEmpty(Program.SystemConfig["mame_joystick_driver"]))
-                retList.Add(Program.SystemConfig["mame_joystick_driver"]);
+            if (SystemConfig.isOptSet("mame_joystick_driver") && !string.IsNullOrEmpty(SystemConfig["mame_joystick_driver"]))
+                retList.Add(SystemConfig["mame_joystick_driver"]);
             else
                 retList.Add("winhybrid");
 
-            if (Program.SystemConfig.isOptSet("mame_ctrlr_profile") && Program.SystemConfig["mame_ctrlr_profile"] != "none")
+            if (SystemConfig.isOptSet("mame_ctrlr_profile") && SystemConfig["mame_ctrlr_profile"] != "none")
             {
-                string ctrlrProfile = Path.Combine(Program.AppConfig.GetFullPath("saves"), "mame", "ctrlr", Program.SystemConfig["mame_ctrlr_profile"] + ".cfg");
-                if (File.Exists(ctrlrProfile) && Program.SystemConfig["mame_ctrlr_profile"] != "per_game")
+                string ctrlrProfile = Path.Combine(AppConfig.GetFullPath("saves"), "mame", "ctrlr", SystemConfig["mame_ctrlr_profile"] + ".cfg");
+                if (File.Exists(ctrlrProfile) && SystemConfig["mame_ctrlr_profile"] != "per_game")
                 {
                     retList.Add("-ctrlr");
-                    retList.Add(Program.SystemConfig["mame_ctrlr_profile"]);
+                    retList.Add(SystemConfig["mame_ctrlr_profile"]);
                 }
-                else if (Program.SystemConfig["mame_ctrlr_profile"] == "per_game")
+                else if (SystemConfig["mame_ctrlr_profile"] == "per_game")
                 {
                     string romName = Path.GetFileNameWithoutExtension(rom);
-                    ctrlrProfile = Path.Combine(Program.AppConfig.GetFullPath("saves"), "mame", "ctrlr", romName + ".cfg");
+                    ctrlrProfile = Path.Combine(AppConfig.GetFullPath("saves"), "mame", "ctrlr", romName + ".cfg");
                     if (File.Exists(ctrlrProfile))
                     {
                         retList.Add("-ctrlr");

--- a/emulatorLauncher/Generators/MessSystem.cs
+++ b/emulatorLauncher/Generators/MessSystem.cs
@@ -543,6 +543,7 @@ namespace emulatorLauncher
                 iniFileName = MachineName;
 
             var bios = AppConfig.GetFullPath("bios");
+            var saves = AppConfig.GetFullPath("saves");
 
             string inipath = Path.Combine(bios, "mame", "ini", iniFileName + ".ini");
             if (File.Exists(inipath))
@@ -576,9 +577,9 @@ namespace emulatorLauncher
                     artwork = Path.Combine(Path.GetDirectoryName(rom), ".artwork");
 
                 if (Directory.Exists(artwork))
-                    commandArray.Add(artwork + ";" + EnsureDirectoryExists(Path.Combine(bios, "mame", "artwork")));
+                    commandArray.Add(artwork + ";" + EnsureDirectoryExists(Path.Combine(saves, "mame", "artwork")));
                 else
-                    commandArray.Add(EnsureDirectoryExists(Path.Combine(bios, "mame", "artwork")));
+                    commandArray.Add(EnsureDirectoryExists(Path.Combine(saves, "mame", "artwork")));
             }
             else
                 commandArray.Add(Path.GetDirectoryName(rom));

--- a/emulatorLauncher/Generators/MessSystem.cs
+++ b/emulatorLauncher/Generators/MessSystem.cs
@@ -570,16 +570,19 @@ namespace emulatorLauncher
                 commandArray.Add("-hashpath");
                 commandArray.Add(EnsureDirectoryExists(Path.Combine(bios, "mame", "hash")));
 
-                commandArray.Add("-artpath");
+                if (!Program.SystemConfig.isOptSet("bezel") || Program.SystemConfig["bezel"] == "none")
+                {
+                    commandArray.Add("-artpath");
 
-                string artwork = Path.Combine(Path.GetDirectoryName(rom), "artwork");
-                if (Directory.Exists(artwork))
-                    artwork = Path.Combine(Path.GetDirectoryName(rom), ".artwork");
+                    string artwork = Path.Combine(Path.GetDirectoryName(rom), "artwork");
+                    if (Directory.Exists(artwork))
+                        artwork = Path.Combine(Path.GetDirectoryName(rom), ".artwork");
 
-                if (Directory.Exists(artwork))
-                    commandArray.Add(artwork + ";" + EnsureDirectoryExists(Path.Combine(saves, "mame", "artwork")));
-                else
-                    commandArray.Add(EnsureDirectoryExists(Path.Combine(saves, "mame", "artwork")));
+                    if (Directory.Exists(artwork))
+                        commandArray.Add(artwork + ";" + EnsureDirectoryExists(Path.Combine(saves, "mame", "artwork")));
+                    else
+                        commandArray.Add(EnsureDirectoryExists(Path.Combine(saves, "mame", "artwork")));
+                }
             }
             else
                 commandArray.Add(Path.GetDirectoryName(rom));

--- a/emulatorLauncher/Generators/MessSystem.cs
+++ b/emulatorLauncher/Generators/MessSystem.cs
@@ -570,7 +570,7 @@ namespace emulatorLauncher
                 commandArray.Add("-hashpath");
                 commandArray.Add(EnsureDirectoryExists(Path.Combine(bios, "mame", "hash")));
 
-                if (!Program.SystemConfig.isOptSet("bezel") || Program.SystemConfig["bezel"] == "none")
+                if (Program.SystemConfig.isOptSet("bezel") && Program.SystemConfig["bezel"] == "none")
                 {
                     commandArray.Add("-artpath");
 

--- a/emulatorLauncher/Generators/MessSystem.cs
+++ b/emulatorLauncher/Generators/MessSystem.cs
@@ -610,7 +610,7 @@ namespace emulatorLauncher
                     commandArray.Add(ctrlrPath);
                 }
 
-                List<string> arguments = Mame64Generator.mameArguments();
+                List<string> arguments = Mame64Generator.mameArguments(rom);
                 if (arguments.Count != 0)
                     commandArray.AddRange(arguments);
             }

--- a/emulatorLauncher/Installer.cs
+++ b/emulatorLauncher/Installer.cs
@@ -28,7 +28,7 @@ namespace emulatorLauncher
             { new Installer("model3", "supermodel") }, 
             { new Installer("supermodel") }, 
             { new Installer("rpcs3") }, { new Installer("ps3", "rpcs3") }, 
-            { new Installer("pcsx2", new string[] { "pcsx2" }, new string[] { "pcsx2-qtx64.exe", "pcsx2x64.exe" }) },
+            { new Installer("pcsx2", new string[] { "pcsx2" }, new string[] { "pcsx2-qt.exe", "pcsx2-qtx64.exe", "pcsx2x64.exe" }) },
             { new Installer("pcsx2-16", "pcsx2-16", "pcsx2.exe") },
             { new Installer("fpinball", "fpinball", "Future Pinball.exe") }, { new Installer("bam", "fpinball", "Future Pinball.exe") }, 
             { new Installer("cemu") }, { new Installer("wiiu", "cemu") },


### PR DESCRIPTION
MAME64:
- add per-game controller profile
- add frequency to resolution (using videomode)
- cleanup of code
- Add one additional artowrk path in saves\mame\ for people wanting to use mame artworks instead of bezels
- disable libretro -artpath command line if a bezel is used to not combien bezel & artwork

PCSX2:
- Add management of new pcsx2 executable (pcsx2-qt.exe)
- Correction of bilinear filtering feature (it has 3 choices in pcsx2)