### PR TITLE
2 fixes for Mame

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -6628,7 +6628,7 @@
     <sharedFeature group="GENERAL SETTINGS" value="bezel"/>
     <sharedFeature group="GENERAL SETTINGS" value="smooth"/>
     <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="videomode"/>
-    <feature name="GAME ASPECT RATIO" group="GENERAL SETTINGS" value="ratio">
+    <feature name="GAME ASPECT RATIO" group="GENERAL SETTINGS" value="mame_ratio">
       <choice name="4/3" value="4:3"/>
       <choice name="16/9" value="16:9"/>
       <choice name="16/10" value="16:10"/>

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -235,8 +235,8 @@ namespace emulatorLauncher
 
             // Aspect ratio
             retList.Add("-aspect");
-            if (SystemConfig.isOptSet("ratio") && !string.IsNullOrEmpty(SystemConfig["ratio"]))
-                retList.Add(SystemConfig["ratio"]);
+            if (SystemConfig.isOptSet("mame_ratio") && !string.IsNullOrEmpty(SystemConfig["mame_ratio"]))
+                retList.Add(SystemConfig["mame_ratio"]);
             else
                 retList.Add("auto");
             

--- a/emulatorLauncher/Generators/MessSystem.cs
+++ b/emulatorLauncher/Generators/MessSystem.cs
@@ -557,35 +557,33 @@ namespace emulatorLauncher
                     commandArray.Add(Path.Combine(bios, "mess") + ";" + bios + ";" + Path.GetDirectoryName(rom));
                 else
                     commandArray.Add(bios + ";" + Path.GetDirectoryName(rom));
-
-                if (injectCfgDirectory)
-                {
-                    commandArray.Add("-cfg_directory");
-                    commandArray.Add(EnsureDirectoryExists(Path.Combine(bios, "mame", "cfg")));
-
-                    commandArray.Add("-inipath");
-                    commandArray.Add(EnsureDirectoryExists(Path.Combine(bios, "mame", "ini")));
-                }
-
-                commandArray.Add("-hashpath");
-                commandArray.Add(EnsureDirectoryExists(Path.Combine(bios, "mame", "hash")));
-
-                if (Program.SystemConfig.isOptSet("bezel") && Program.SystemConfig["bezel"] == "none")
-                {
-                    commandArray.Add("-artpath");
-
-                    string artwork = Path.Combine(Path.GetDirectoryName(rom), "artwork");
-                    if (Directory.Exists(artwork))
-                        artwork = Path.Combine(Path.GetDirectoryName(rom), ".artwork");
-
-                    if (Directory.Exists(artwork))
-                        commandArray.Add(artwork + ";" + EnsureDirectoryExists(Path.Combine(saves, "mame", "artwork")));
-                    else
-                        commandArray.Add(EnsureDirectoryExists(Path.Combine(saves, "mame", "artwork")));
-                }
             }
+
             else
                 commandArray.Add(Path.GetDirectoryName(rom));
+
+            if (injectCfgDirectory)
+            {
+                commandArray.Add("-cfg_directory");
+                commandArray.Add(EnsureDirectoryExists(Path.Combine(bios, "mame", "cfg")));
+
+                commandArray.Add("-inipath");
+                commandArray.Add(EnsureDirectoryExists(Path.Combine(bios, "mame", "ini")));
+            }
+
+            commandArray.Add("-hashpath");
+            commandArray.Add(EnsureDirectoryExists(Path.Combine(bios, "mame", "hash")));
+
+            commandArray.Add("-artpath");
+
+            string artwork = Path.Combine(Path.GetDirectoryName(rom), "artwork");
+            if (Directory.Exists(artwork))
+                artwork = Path.Combine(Path.GetDirectoryName(rom), ".artwork");
+
+            if (Directory.Exists(artwork))
+                commandArray.Add(artwork + ";" + EnsureDirectoryExists(Path.Combine(saves, "mame", "artwork")));
+            else
+                commandArray.Add(EnsureDirectoryExists(Path.Combine(saves, "mame", "artwork")));
             
             if (!string.IsNullOrEmpty(AppConfig["screenshots"]) && Directory.Exists(AppConfig.GetFullPath("screenshots")))
             {


### PR DESCRIPTION
Fix 1: ratio, when ratio in mame system set to AUTO and global settings ratio set, wrong "ratio" value was  sent to Mame

Fix 2: -artpath was not correctly set when running MESS systems with MAME standalone & libretro:MAME