### PR TITLE
Mame standalone - do not remove emulator artwork path - was breaking bgfx shaders

### DIFF
--- a/emulatorLauncher/Generators/Duckstation.Generator.cs
+++ b/emulatorLauncher/Generators/Duckstation.Generator.cs
@@ -75,12 +75,26 @@ namespace emulatorLauncher
 
             string args = string.Join(" ", commandArray);
 
-            return new ProcessStartInfo()
+            if (!SystemConfig.getOptBoolean("disable_fullscreen"))
             {
-                FileName = exe,
-                WorkingDirectory = _path,
-                Arguments = args + " \"" + rom + "\"",
-            };
+                return new ProcessStartInfo()
+                {
+                    FileName = exe,
+                    WorkingDirectory = _path,
+                    Arguments = args + " \"" + rom + "\"",
+                    WindowStyle = ProcessWindowStyle.Minimized,
+                };
+            }
+
+            else
+            {
+                return new ProcessStartInfo()
+                {
+                    FileName = exe,
+                    WorkingDirectory = _path,
+                    Arguments = args + " \"" + rom + "\"",
+                };
+            }
         }
 
         private string GetDefaultpsxLanguage()

--- a/emulatorLauncher/Generators/Mame64.Generator.cs
+++ b/emulatorLauncher/Generators/Mame64.Generator.cs
@@ -67,7 +67,7 @@ namespace emulatorLauncher
                     if (SystemConfig.isOptSet("disable_artwork") && SystemConfig.getOptBoolean("disable_artwork"))
                         commandArray.Add(artPath);
                     else
-                        commandArray.Add(artPath + ";" + Path.Combine(AppConfig.GetFullPath("saves"), "mame", "artwork"));
+                        commandArray.Add(artPath + ";" + Path.Combine(path, "artwork") + ";" + Path.Combine(AppConfig.GetFullPath("saves"), "mame", "artwork"));
                 }
 
                 // Snapshots

--- a/emulatorLauncher/Generators/Pcsx2.Controllers.cs
+++ b/emulatorLauncher/Generators/Pcsx2.Controllers.cs
@@ -286,7 +286,10 @@ namespace emulatorLauncher
             { InputKey.y, new KeyValuePair<string, string>("SaveStateToSlot", "Keyboard/F1") },
             { InputKey.r3, new KeyValuePair<string, string>("Screenshot", "Keyboard/F8") },
             { InputKey.up, new KeyValuePair<string, string>("NextSaveStateSlot", "Keyboard/F2") },
-            { InputKey.down, new KeyValuePair<string, string>("PreviousSaveStateSlot", "Keyboard/Shift & Keyboard/F2") },            
+            { InputKey.down, new KeyValuePair<string, string>("PreviousSaveStateSlot", "Keyboard/Shift & Keyboard/F2") },
+            { InputKey.left, new KeyValuePair<string, string>("ToggleSlowMotion", "Keyboard/Shift & Keyboard/Backtab") },
+            { InputKey.right, new KeyValuePair<string, string>("ToggleTurbo", "Keyboard/Tab") },
+            { InputKey.start, new KeyValuePair<string, string>("ShutdownVM", "") },
         };
 
 

--- a/emulatorLauncher/Generators/Uae.Generator.cs
+++ b/emulatorLauncher/Generators/Uae.Generator.cs
@@ -18,6 +18,15 @@ namespace emulatorLauncher
             if (!File.Exists(exe))
                 return null;
 
+            if (Path.GetExtension(rom).ToLower() == ".uae")
+            {
+                return new ProcessStartInfo()
+                {
+                    FileName = exe,
+                    Arguments = "\"" + rom + "\"",
+                    WorkingDirectory = path,
+                };
+            }
 
             var disks = DetectDiscs(rom);
             if (disks.Count == 0)

--- a/emulatorLauncher/Generators/Yuzu.Controllers.cs
+++ b/emulatorLauncher/Generators/Yuzu.Controllers.cs
@@ -219,6 +219,9 @@ namespace emulatorLauncher
 
             ProcessStick(controller, player, "lstick", ini, yuzuGuid, index);
             ProcessStick(controller, player, "rstick", ini, yuzuGuid, index);
+
+            //Write exit shortcut
+            ini.WriteValue("UI", "Shortcuts\\Main%20Window\\Exit%20yuzu\\Controller_KeySeq", "Home+Minus");
         }
 
         private string FromInput(Controller controller, Input input, string guid, int index)


### PR DESCRIPTION
Mame standalone - do not remove emulator artwork path - was breaking bgfx shaders

WINUae: fix running .uae extensions

PCSX2 & yuzu: add exit shortcut