### PR TITLE
citra - align paths with libretro paths

### DIFF
--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -7352,10 +7352,7 @@
         <choice name="USER MAPPING 2" value="userjoystick2"/>
         <choice name="USER MAPPING 3" value="userjoystick3"/>
       </feature>
-      <feature submenu="CONTROLS" name="USE MOUSE" group="ADVANCED SETTINGS" value="msx_mouse" description="Plug a mouse in joyport, this will remove plugged joysticks." order="61">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="CONTROLS" name="USE MOUSE" group="ADVANCED SETTINGS" value="msx_mouse" description="Plug a mouse in joyport, this will remove plugged joysticks." order="61" preset="switch"/>
     </system>
     <system name="msx2">
       <feature submenu="EMULATION" name="MACHINE" group="ADVANCED SETTINGS" value="msx_machine" description="Select the machine to emulate.">
@@ -7387,10 +7384,7 @@
         <choice name="USER MAPPING 2" value="userjoystick2"/>
         <choice name="USER MAPPING 3" value="userjoystick3"/>
       </feature>
-      <feature submenu="CONTROLS" name="USE MOUSE" group="ADVANCED SETTINGS" value="msx_mouse" description="Plug a mouse in joyport, this will remove plugged joysticks." order="61">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="CONTROLS" name="USE MOUSE" group="ADVANCED SETTINGS" value="msx_mouse" description="Plug a mouse in joyport, this will remove plugged joysticks." order="61" preset="switch"/>
     </system>
     <system name="msx2+">
       <feature submenu="EMULATION" name="MACHINE" group="ADVANCED SETTINGS" value="msx_machine" description="Select the machine to emulate.">
@@ -7422,10 +7416,7 @@
         <choice name="USER MAPPING 2" value="userjoystick2"/>
         <choice name="USER MAPPING 3" value="userjoystick3"/>
       </feature>
-      <feature submenu="CONTROLS" name="USE MOUSE" group="ADVANCED SETTINGS" value="msx_mouse" description="Plug a mouse in joyport, this will remove plugged joysticks." order="61">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="CONTROLS" name="USE MOUSE" group="ADVANCED SETTINGS" value="msx_mouse" description="Plug a mouse in joyport, this will remove plugged joysticks." order="61" preset="switch"/>
     </system>
     <system name="msxturbor">
       <feature submenu="EMULATION" name="MACHINE" group="ADVANCED SETTINGS" value="msx_machine" description="Select the machine to emulate.">
@@ -7457,15 +7448,9 @@
         <choice name="USER MAPPING 2" value="userjoystick2"/>
         <choice name="USER MAPPING 3" value="userjoystick3"/>
       </feature>
-      <feature submenu="CONTROLS" name="USE MOUSE" group="ADVANCED SETTINGS" value="msx_mouse" description="Plug a mouse in joyport, this will remove plugged joysticks." order="61">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="CONTROLS" name="USE MOUSE" group="ADVANCED SETTINGS" value="msx_mouse" description="Plug a mouse in joyport, this will remove plugged joysticks." order="61" preset="switch"/>
     </system>
-    <feature submenu="VIDEO" name="DISABLE FULLSCREEN" value="msx_fullscreen" group="ADVANCED SETTINGS" order="20">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="VIDEO" name="DISABLE FULLSCREEN" value="msx_fullscreen" group="ADVANCED SETTINGS" order="20" preset="switch"/>
     <feature submenu="VIDEO" name="UPSCALE RATIO" value="msx_scale" group="ADVANCED SETTINGS" order="21">
       <choice name="2X" value="2"/>
       <choice name="3X" value="3"/>
@@ -7559,18 +7544,9 @@
         <choice name="BLEND (Top first)" value="5"/>
         <choice name="BLEND (Bottom first)" value="6"/>
       </feature>
-      <feature submenu="VIDEO" name="WIDESCREEN PATCHES" group="ADVANCED SETTINGS" value="widescreen_patch" description="Automatically load widescreen patches on game start-up, might cause issues.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="VIDEO" name="NO-INTERLACING PATCHES" group="ADVANCED SETTINGS" value="interlacing_patch" description="Automatically load no-interlacing patches on game start-up, might cause issues.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="VIDEO" name="DISABLE FULLSCREEN" group="ADVANCED SETTINGS" value="disable_fullscreen" description="Use this option if PCSX2 is not displaying on the correct monitor.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="VIDEO" name="WIDESCREEN PATCHES" group="ADVANCED SETTINGS" value="widescreen_patch" description="Automatically load widescreen patches on game start-up, might cause issues." preset="switch"/>
+      <feature submenu="VIDEO" name="NO-INTERLACING PATCHES" group="ADVANCED SETTINGS" value="interlacing_patch" description="Automatically load no-interlacing patches on game start-up, might cause issues." preset="switch"/>
+      <feature submenu="VIDEO" name="DISABLE FULLSCREEN" group="ADVANCED SETTINGS" value="disable_fullscreen" description="Use this option if PCSX2 is not displaying on the correct monitor." preset="switch"/>
       <feature submenu="VISUAL RENDERING" name="TEXTURE PRELOADING" group="ADVANCED SETTINGS" value="texture_preloading" description="Upload all textures at once, can improve performance.">
         <choice name="NONE" value="0"/>
         <choice name="PARTIAL" value="1"/>
@@ -7787,10 +7763,7 @@
         <choice name="NO" value="false"/>
         <choice name="YES" value="true"/>
       </feature>
-      <feature submenu="USER INTERFACE" name="DRAW STATISTICS" group="ADVANCED SETTINGS" value="DrawFramerate" description="Enable performance statistics.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="USER INTERFACE" name="DRAW STATISTICS" group="ADVANCED SETTINGS" value="DrawFramerate" description="Enable performance statistics." preset="switch"/>
       <feature submenu="USER INTERFACE" name="NOTIFICATIONS" group="ADVANCED SETTINGS" value="Notifications" description="Show notifications.">
         <choice name="NO" value="false"/>
         <choice name="YES" value="true"/>
@@ -7841,14 +7814,8 @@
       <choice name="SSE2" value="GSdx32-SSE2.dll"/>
       <choice name="SSE4" value="GSdx32-SSE4.dll"/>
     </feature>
-    <feature submenu="EMULATION" name="MANUAL HACKS" group="ADVANCED SETTINGS" value="UserHacks" description="Enable manual hacks below, otherwise hacks will be apllied automatically." order="90">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="EMULATION" name="LOWER GS PRECISION (HACK)" group="ADVANCED SETTINGS" value="Offset" description="Avoid gap between pixels when upscaling. Fix Wild Arms text, SoulCalibur ghosting." order="90">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="EMULATION" name="MANUAL HACKS" group="ADVANCED SETTINGS" value="UserHacks" description="Enable manual hacks below, otherwise hacks will be apllied automatically." order="90" preset="switch"/>
+    <feature submenu="EMULATION" name="LOWER GS PRECISION (HACK)" group="ADVANCED SETTINGS" value="Offset" description="Avoid gap between pixels when upscaling. Fix Wild Arms text, SoulCalibur ghosting." order="90" preset="switch"/>
     <feature submenu="EMULATION" name="HALF-SCREEN (HACK)" group="ADVANCED SETTINGS" value="UserHacks_Half_Bottom_Override" description="'Auto' will controls the half-screen fix detection on texture shuffling." order="90">
       <choice name="FORCE DISABLE (For Xenosaga games)" value="0"/>
       <choice name="FORCE ENABLE (If issues on Auto)" value="1"/>
@@ -7864,14 +7831,8 @@
       <choice name="HALF" value="1"/>
       <choice name="FULL" value="2"/>
     </feature>
-    <feature submenu="EMULATION" name="ALIGN SPRITE (HACK)" group="ADVANCED SETTINGS" value="align_sprite" description="Fix issues with upscaling in Namco games (Ace Combat, Tekken, SoulCalibur...)." order="90">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="EMULATION" name="MERGE SPRITE (HACK)" group="ADVANCED SETTINGS" value="UserHacks_merge_pp_sprite" description="Replaces post-processing multiple paving sprites by a single fat sprite." order="90">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="EMULATION" name="ALIGN SPRITE (HACK)" group="ADVANCED SETTINGS" value="align_sprite" description="Fix issues with upscaling in Namco games (Ace Combat, Tekken, SoulCalibur...)." order="90" preset="switch"/>
+    <feature submenu="EMULATION" name="MERGE SPRITE (HACK)" group="ADVANCED SETTINGS" value="UserHacks_merge_pp_sprite" description="Replaces post-processing multiple paving sprites by a single fat sprite." order="90" preset="switch"/>
     <feature submenu="EMULATION" name="TEXTURE OFFSETS (HACK)" group="ADVANCED SETTINGS" value="TextureOffsets" description="Offset for the ST/UV texture coordinates." order="90">
       <choice name="X:0500 Y:0500 (Persona 3, Haunting Ground)" value="1"/>
       <choice name="X:0000 Y:1000 (Xenosaga)" value="2"/>
@@ -7905,18 +7866,9 @@
       <choice name="NO" value="0"/>
       <choice name="YES" value="7"/>
     </feature>
-    <feature submenu="VISUAL RENDERING" name="ANTI ALIASING" group="ADVANCED SETTINGS" value="fxaa" description="Set Anti Aliasing for rendered content.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="VISUAL RENDERING" name="LINEAR FILTERING" group="ADVANCED SETTINGS" value="bilinear_filtering" description="Use bilinear filtering when upscaling/downscaling the image to the screen.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="VISUAL RENDERING" name="ALLOW 8 BIT TEXTURES" group="ADVANCED SETTINGS" value="allow_paltex" description="When disabled the CPU will convert directly the texture to 32 bit. Basically a trade off GPU/CPU.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="VISUAL RENDERING" name="ANTI ALIASING" group="ADVANCED SETTINGS" value="fxaa" description="Set Anti Aliasing for rendered content." preset="switch"/>
+    <feature submenu="VISUAL RENDERING" name="LINEAR FILTERING" group="ADVANCED SETTINGS" value="bilinear_filtering" description="Use bilinear filtering when upscaling/downscaling the image to the screen." preset="switch"/>
+    <feature submenu="VISUAL RENDERING" name="ALLOW 8 BIT TEXTURES" group="ADVANCED SETTINGS" value="allow_paltex" description="When disabled the CPU will convert directly the texture to 32 bit. Basically a trade off GPU/CPU." preset="switch"/>
     <feature submenu="VISUAL RENDERING" name="ANISOTROPIC FILTERING" group="ADVANCED SETTINGS" value="anisotropic_filtering" description="Enhance the quality of textures on surface." order="90">
       <choice name="NO" value="0"/>
       <choice name="2x" value="2"/>
@@ -7928,18 +7880,9 @@
       <choice name="YES" value="0"/>
       <choice name="NO" value="1"/>
     </feature>
-    <feature submenu="EMULATION" name="SPEED HACKS" group="ADVANCED SETTINGS" value="negdivhack" description="Significantly improves performances for CPU with 3+ cores.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="USER INTERFACE" name="DRAW STATISTICS" group="ADVANCED SETTINGS" value="DrawFramerate" description="Enable monitoring.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="USER INTERFACE" name="NOTIFICATIONS" group="ADVANCED SETTINGS" value="Notifications" description="Show notifications." order="90">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="EMULATION" name="SPEED HACKS" group="ADVANCED SETTINGS" value="negdivhack" description="Significantly improves performances for CPU with 3+ cores." preset="switch"/>
+    <feature submenu="USER INTERFACE" name="DRAW STATISTICS" group="ADVANCED SETTINGS" value="DrawFramerate" description="Enable monitoring." preset="switch"/>
+    <feature submenu="USER INTERFACE" name="NOTIFICATIONS" group="ADVANCED SETTINGS" value="Notifications" description="Show notifications." order="90" preset="switch"/>
   </emulator>
   <!-- PHOENIX -->
   <emulator name="phoenix">
@@ -7973,10 +7916,7 @@
       <choice name="1:1" value="0.562500"/>
       <choice name="STRETCH" value="stretch"/>
     </feature>
-    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="ppsspp_vsync">
-      <choice name="YES" value="1"/>
-      <choice name="NO" value="0"/>
-    </feature>
+    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="ppsspp_vsync" preset="switchoff"/>
     <feature name="INTEGER SCALING" group="GENERAL SETTINGS" value="Integer_Scaling" preset="switch"/>
     <feature name="SHADER SET" group="GENERAL SETTINGS" value="ppsspp_shader" description="Select a shader to apply.">
       <choice name="GLSL HQ x4" value="4xHqGLSL"/>
@@ -8132,10 +8072,7 @@
         <choice name="48X" value="48"/>
       </feature>
     </system>
-    <feature submenu="EMULATION" name="PERFORMANCE MODE" group="ADVANCED SETTINGS" value="Speed_Hack" description="Improves the emulation performance at the cost of accuracy.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="EMULATION" name="PERFORMANCE MODE" group="ADVANCED SETTINGS" value="Speed_Hack" description="Improves the emulation performance at the cost of accuracy." preset="switch"/>
   </emulator>
   <!-- REDREAM -->
   <emulator name="redream">
@@ -8468,10 +8405,7 @@
       <choice name="OPENAL" value="OpenAl"/>
       <choice name="SOUNDIO" value="SoundIo"/>
     </feature>
-    <feature submenu="CONTROLS" name="INVERT A/B AND X/Y" group="ADVANCED SETTINGS" value="ryujinx_gamepadbuttons" description="Invert A/B and X/Y buttons on Xbox controllers.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="CONTROLS" name="INVERT A/B AND X/Y" group="ADVANCED SETTINGS" value="ryujinx_gamepadbuttons" description="Invert A/B and X/Y buttons on Xbox controllers." preset="switch"/>
     <feature submenu="CONTROLS" name="RUMBLE" group="ADVANCED SETTINGS" value="ryujinx_enable_rumble" description="Enable controller's rumble effects.">
       <choice name="NO" value="false"/>
       <choice name="YES" value="true"/>
@@ -8492,10 +8426,7 @@
       <choice name="YES" value="true"/>
       <choice name="NO" value="false"/>
     </feature>
-    <feature submenu="VIDEO" name="DISABLE RATIO CORRECTION" group="ADVANCED SETTINGS" value="ratio">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="VIDEO" name="DISABLE RATIO CORRECTION" group="ADVANCED SETTINGS" value="ratio" preset="switch"/>
     <feature submenu="VIDEO" name="RENDER METHOD" group="ADVANCED SETTINGS" value="render_mode">
       <choice name="HERCULES GREEN" value="hercGreen"/>
       <choice name="HERCULES AMBER" value="hercAmber"/>
@@ -8542,10 +8473,7 @@
       <choice name="8X" value="8"/>
       <choice name="16X" value="16"/>
     </feature>
-    <feature submenu="EMULATION" name="ALLOW UNSUPPORTED GAMES" group="ADVANCED SETTINGS" value="unsupported_games" description="Disable warning when running games that are not fully supported.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="EMULATION" name="ALLOW UNSUPPORTED GAMES" group="ADVANCED SETTINGS" value="unsupported_games" description="Disable warning when running games that are not fully supported." preset="switch"/>
     <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="gfx_mode">
       <choice name="OPENGL" value="opengl"/>
       <choice name="SDL SURFACE" value="surfacesdl"/>
@@ -8578,41 +8506,23 @@
       <choice name="STRETCH" value="2"/>
     </feature>
     <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="videomode"/>
-    <feature submenu="VIDEO" name="NEW 3D ENGINE" group="ADVANCED SETTINGS" value="new3Dengine" description="Default is ON, setting to OFF might fix compatibility for older GPU.">
-      <choice name="ON" value="1"/>
-      <choice name="OFF" value="0"/>
-    </feature>
-	<feature submenu="VIDEO" name="QUAD RENDERING" group="ADVANCED SETTINGS" value="quadRendering" description="Enable proper quad rendering. For higher end systems.">
-      <choice name="OFF" value="0"/>
-      <choice name="ON" value="1"/>
-    </feature>
-	<feature submenu="EMULATION" name="THROTTLE" group="ADVANCED SETTINGS" value="throttle" description="Default is ON, use this setting to remove the 60hz limit, might break games">
-      <choice name="ON" value="1"/>
-      <choice name="OFF" value="0"/>
-    </feature>
+    <feature submenu="VIDEO" name="NEW 3D ENGINE" group="ADVANCED SETTINGS" value="new3Dengine" description="Default is ON, setting to OFF might fix compatibility for older GPU." preset="switchoff"/>
+	<feature submenu="VIDEO" name="QUAD RENDERING" group="ADVANCED SETTINGS" value="quadRendering" description="Enable proper quad rendering. For higher end systems." preset="switch"/>
+	<feature submenu="EMULATION" name="THROTTLE" group="ADVANCED SETTINGS" value="throttle" description="Default is ON, use this setting to remove the 60hz limit, might break games" preset="switchoff"/>
     <feature submenu="CONTROLS" name="CROSSHAIRS" group="ADVANCED SETTINGS" value="crosshairs" description="Enable crosshairs in shooting games">
       <choice name="None" value="0"/>
       <choice name="P1 only" value="1"/>
       <choice name="P2 only" value="2"/>
       <choice name="P1 &amp; P2" value="3"/>
     </feature>
-    <feature submenu="CONTROLS" name="ENABLE FORCE FEEDBACK" group="ADVANCED SETTINGS" value="forceFeedback" description="Enable force feedback for supported controllers">
-      <choice name="OFF" value="0"/>
-      <choice name="ON" value="1"/>
-    </feature>
+    <feature submenu="CONTROLS" name="ENABLE FORCE FEEDBACK" group="ADVANCED SETTINGS" value="forceFeedback" description="Enable force feedback for supported controllers" preset="switch"/>
   </emulator>
   <!-- TEKNOPARROT -->
   <emulator name="teknoparrot">
     <sharedFeature group="GENERAL SETTINGS" value="disableautocontrollers"/>
     <sharedFeature group="ADVANCED SETTINGS" value="videomode"/>
-    <feature submenu="EMULATION" name="DISABLE ADMIN RIGHTS" group="ADVANCED SETTINGS" value="requires_admin">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="VIDEO" name="DISABLE FULLSCREEN" group="ADVANCED SETTINGS" value="tp_nofs">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="EMULATION" name="DISABLE ADMIN RIGHTS" group="ADVANCED SETTINGS" value="requires_admin" preset="switch"/>
+    <feature submenu="VIDEO" name="DISABLE FULLSCREEN" group="ADVANCED SETTINGS" value="tp_nofs" preset="switch"/>
     <feature submenu="CONTROLS" name="JOYSTICK DEADZONE" group="ADVANCED SETTINGS" value="tp_stooz" description="This is helpful in driving games to make it less 'twitchy' when using a controller to steer.">
       <choice name="5%" value="5"/>
       <choice name="10%" value="10"/>
@@ -8703,14 +8613,8 @@
       <choice name="EMULATOR UI (MANUAL)" value="2"/>
       <choice name="FRONTEND UI (MANUAL)" value="1"/>
     </feature>
-    <feature submenu="MODULES" name="libhttp" group="ADVANCED SETTINGS" value="libhttp" description="Required to fix Tales of Hearts R, only valid if modules are managed from Retrobat.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="MODULES" name="libscemp4" group="ADVANCED SETTINGS" value="libscemp4" description="Required to fix Street Fighter vs Tekken, only valid if modules are managed from Retrobat.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="MODULES" name="libhttp" group="ADVANCED SETTINGS" value="libhttp" description="Required to fix Tales of Hearts R, only valid if modules are managed from Retrobat." preset="switch"/>
+    <feature submenu="MODULES" name="libscemp4" group="ADVANCED SETTINGS" value="libscemp4" description="Required to fix Street Fighter vs Tekken, only valid if modules are managed from Retrobat." preset="switch"/>
   </emulator>
   <!-- WINDOWS -->
   <emulator name="windows" features="padtokeyboard"/>
@@ -8721,10 +8625,7 @@
       <choice name="OFF" value="false"/>
     </feature>
     <sharedFeature group="ADVANCED SETTINGS" value="videomode" order="10"/>
-    <feature submenu="EMULATION" name="CYCLE EXACT" group="ADVANCED SETTINGS" value="cycleexact" description="Increase accuracy, can fix some issues of sound and speed." order="21">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="EMULATION" name="CYCLE EXACT" group="ADVANCED SETTINGS" value="cycleexact" description="Increase accuracy, can fix some issues of sound and speed." order="21" preset="switch"/>
     <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="winuae_gfxrenderer" order="60">
       <choice name="D3D9" value="direct3d"/>
       <choice name="D3D11 (HARDWARE)" value="direct3d11"/>
@@ -8737,34 +8638,16 @@
       </feature>
     </system>
     <system name="amiga1200">
-      <feature submenu="EMULATION" name="ENABLE JIT" group="ADVANCED SETTINGS" value="amiga_jit" description="Enable Just In Time emilation, increases emulation speed, not compatible with cycle exact." order="20">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="EMULATION" name="USE FPU" group="ADVANCED SETTINGS" value="amiga_fpu" description="Enable Floating Point Unit, usually useful for later 3D games." order="22">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="EMULATION" name="ENABLE JIT" group="ADVANCED SETTINGS" value="amiga_jit" description="Enable Just In Time emilation, increases emulation speed, not compatible with cycle exact." order="20" preset="switch"/>
+      <feature submenu="EMULATION" name="USE FPU" group="ADVANCED SETTINGS" value="amiga_fpu" description="Enable Floating Point Unit, usually useful for later 3D games." order="22" preset="switch"/>
     </system>
     <system name="amigacd32">
-      <feature submenu="EMULATION" name="ENABLE JIT" group="ADVANCED SETTINGS" value="amiga_jit" description="Enable Just In Time emilation, increases emulation speed, not compatible with cycle exact." order="20">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="EMULATION" name="USE FPU" group="ADVANCED SETTINGS" value="amiga_fpu" description="Enable Floating Point Unit, usually useful for later 3D games." order="22">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="EMULATION" name="ENABLE JIT" group="ADVANCED SETTINGS" value="amiga_jit" description="Enable Just In Time emilation, increases emulation speed, not compatible with cycle exact." order="20" preset="switch"/>
+      <feature submenu="EMULATION" name="USE FPU" group="ADVANCED SETTINGS" value="amiga_fpu" description="Enable Floating Point Unit, usually useful for later 3D games." order="22" preset="switch"/>
     </system>
     <system name="amiga4000">
-      <feature submenu="EMULATION" name="ENABLE JIT" group="ADVANCED SETTINGS" value="amiga_jit" description="Enable Just In Time emilation, increases emulation speed, not compatible with cycle exact." order="20">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="EMULATION" name="USE FPU" group="ADVANCED SETTINGS" value="amiga_fpu" description="Enable Floating Point Unit, usually useful for later 3D games." order="22">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="EMULATION" name="ENABLE JIT" group="ADVANCED SETTINGS" value="amiga_jit" description="Enable Just In Time emilation, increases emulation speed, not compatible with cycle exact." order="20" preset="switch"/>
+      <feature submenu="EMULATION" name="USE FPU" group="ADVANCED SETTINGS" value="amiga_fpu" description="Enable Floating Point Unit, usually useful for later 3D games." order="22" preset="switch"/>
     </system>
   </emulator>
   <!-- XEMU -->
@@ -9064,6 +8947,5 @@
       <choice name="LEFT" value="left"/>
       <choice name="RIGHT" value="right"/>
     </feature>
-
   </emulator>
 </features>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -783,6 +783,10 @@
         <choice name="TOUCHSCREEN POINTER" value="Touchscreen Pointer"/>
         <choice name="C-STICK" value="C-Stick"/>
       </feature>
+      <feature submenu="CONTROLS" name="SHOW TOUCHSCREEN POINTER" group="ADVANCED SETTINGS" value="citra_render_touchscreen" description="Display a small pointer on touchscreen.">
+        <choice name="NO" value="disabled"/>
+        <choice name="YES" value="enabled"/>
+      </feature>
     </core>
     <!--<core name="citra_canary">
       <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -5840,7 +5840,7 @@
       <choice name="Português" value="9"/>
       <choice name="Русский (Russian)" value="10"/>
     </feature>
-    <feature submenu="VISUAL RENDERING" name="ASYNCHRONOUS TEXTURE COMPILATION" group="ADVANCED SETTINGS" value="async_texture" description="Can improve performance on more powerful GPUs that have spare headroom. Only works with Vulkan renderer." preset="switch"/>
+    <feature submenu="VISUAL RENDERING" name="ASYNCHRONOUS TEXTURE COMPILATION" group="ADVANCED SETTINGS" value="async_texture" description="Can improve performance on more powerful GPUs that have spare headroom. Only works with Vulkan renderer.">
       <choice name="NO" value="false"/>
       <choice name="YES" value="true"/>
     </feature>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -8148,8 +8148,7 @@
   </emulator>
   <!-- PPSSPP -->
   <emulator name="ppsspp">
-    <sharedFeature group="GENERAL SETTINGS" value="ratio"/>
-    <feature name="INTERNAL RESOLUTION" group="GENERAL SETTINGS" value="internal_resolution">
+    <feature name="INTERNAL RESOLUTION" group="GENERAL SETTINGS" value="ppsspp_resolution">
       <choice name="1:1" value="0"/>
       <choice name="x1" value="1"/>
       <choice name="x2" value="2"/>
@@ -8162,11 +8161,72 @@
       <choice name="x9" value="9"/>
       <choice name="x10" value="10"/>
     </feature>
-    <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="videomode"/>
-    <feature submenu="EMULATION" name="FRAME SKIP" group="ADVANCED SETTINGS" value="frameskip">
-      <choice name="NO" value="0"/>
+    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="ppsspp_vsync">
       <choice name="YES" value="1"/>
+      <choice name="NO" value="0"/>
     </feature>
+    <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="videomode"/>
+    <feature submenu="VIDEO" name="FRAMESKIP" group="ADVANCED SETTINGS" value="ppsspp_frame_skipping" description="Skip frames to improve performance (smoothless).">
+      <choice name="NO" value="0"/>
+      <choice name="1" value="1"/>
+      <choice name="2" value="2"/>
+      <choice name="3" value="3"/>
+      <choice name="4" value="4"/>
+      <choice name="5" value="5"/>
+      <choice name="6" value="6"/>
+      <choice name="7" value="7"/>
+      <choice name="8" value="8"/>
+    </feature>
+    <feature submenu="VIDEO" name="FRAMESKIP TYPE" group="ADVANCED SETTINGS" value="ppsspp_frameskip_type" description="Type of Frame skipping.">
+      <choice name="NUMBER OF FRAMES" value="0"/>
+      <choice name="PERCENT OF FPS" value="1"/>
+    </feature>
+    <feature submenu="VISUAL RENDERING" name="ANTI ALIASING (MSAA)" group="ADVANCED SETTINGS" value="ppsspp_msaa" description="Set Multi-Sampled Anti Aliasing level for rendered content.">
+      <choice name="OFF" value="0"/>
+      <choice name="2X" value="1"/>
+      <choice name="4X" value="2"/>
+      <choice name="8X" value="3"/>
+    </feature>
+    <feature submenu="VISUAL RENDERING" name="TEXTURES ENHANCEMENT METHOD" group="ADVANCED SETTINGS" value="ppsspp_textureenhancement" description="Choose between various texture enhancement filters.">
+      <choice name="xBRZ" value="0"/>
+      <choice name="Hybrid" value="1"/>
+      <choice name="Bicubic" value="2"/>
+      <choice name="Hybrid + Bicubic" value="3"/>
+      <choice name="HARDWARE 2xBRZ" value="Tex2xBRZ"/>
+      <choice name="HARDWARE 4xBRZ" value="Tex4xBRZ"/>
+      <choice name="HARDWARE MMPX" value="TexMMPX"/>
+    </feature>
+    <feature submenu="VISUAL RENDERING" name="TEXTURES ENHANCEMENT LEVEL" group="ADVANCED SETTINGS" value="ppsspp_textureenhancement_level" description="Choose level of textures scaling.">
+      <choice name="OFF" value="1"/>
+      <choice name="2x" value="2"/>
+      <choice name="3x" value="3"/>
+      <choice name="4x" value="4"/>
+      <choice name="5x" value="5"/>
+    </feature>
+    <feature submenu="VISUAL RENDERING" name="ANISOTROPIC FILTER" group="ADVANCED SETTINGS" value="ppsspp_anisotropicfilter" description="Enhance the quality of textures on surface.">
+      <choice name="OFF" value="0"/>
+      <choice name="2X" value="1"/>
+      <choice name="4X" value="2"/>
+      <choice name="8X" value="3"/>
+      <choice name="16X" value="4"/>
+    </feature>
+    <feature submenu="VISUAL RENDERING" name="TEXTURE FILTERING" group="ADVANCED SETTINGS" value="ppsspp_texture_filtering" description="Select texture filtering mode.">
+      <choice name="NEAREST NEIGHBOR" value="2"/>
+      <choice name="LINEAR" value="3"/>
+      <choice name="AUTO MAX QUALITY" value="4"/>
+    </feature>
+    <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="ppsspp_backend">
+      <choice name="OPENGL" value="0 (OPENGL)"/>
+      <choice name="DIRECT3D 9" value="1 (DIRECT3D9)"/>
+      <choice name="DIRECT3D 11" value="2 (DIRECT3D11)"/>
+      <choice name="VULKAN" value="3 (VULKAN)"/>
+    </feature>
+    <feature submenu="DRIVERS" name="AUDIO" group="ADVANCED SETTINGS" value="ppsspp_audiobackend">
+      <choice name="DIRECTSOUND (compatible)" value="1"/>
+      <choice name="WASAPI (fast)" value="2"/>
+    </feature>
+    <feature submenu="CONTROLS" name="USE MOUSE" group="ADVANCED SETTINGS" value="ppsspp_mouse" preset="switch"/>
+    <feature submenu="CONTROLS" name="USE O TO CONFIRM (EAST)" group="ADVANCED SETTINGS" value="ppsspp_confirmbutton" preset="switch"/>
     <sharedFeature submenu="USER INTERFACE" group="ADVANCED SETTINGS" value="discord"/>
   </emulator>
   <!-- RAINE -->

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -8161,7 +8161,7 @@
       <choice name="x9" value="9"/>
       <choice name="x10" value="10"/>
     </feature>
-    <feature name="INTERNAL RESOLUTION" group="GENERAL SETTINGS" value="ppsspp_ratio">
+    <feature name="ASPECT RATIO" group="GENERAL SETTINGS" value="ppsspp_ratio">
       <choice name="16:9" value="1.000000"/>
       <choice name="4:3" value="0.750000"/>
       <choice name="1:1" value="0.562500"/>
@@ -8172,6 +8172,28 @@
       <choice name="NO" value="0"/>
     </feature>
     <feature name="INTEGER SCALING" group="GENERAL SETTINGS" value="Integer_Scaling" preset="switch"/>
+    <feature name="SHADER SET" group="GENERAL SETTINGS" value="ppsspp_shader" description="Select a shader to apply.">
+      <choice name="GLSL HQ x4" value="4xHqGLSL"/>
+      <choice name="5xBR" value="5xBR"/>
+      <choice name="5xBR-lv2" value="5xBR-lv2"/>
+      <choice name="COLOR ANTIALIASING" value="AAColor"/>
+      <choice name="BICUBIC UPSCALER" value="UpscaleBicubic"/>
+      <choice name="BLOOM" value="Bloom"/>
+      <choice name="CRT" value="CRT"/>
+      <choice name="CARTOON" value="Cartoon"/>
+      <choice name="COLOR CORRECTION" value="ColorCorrection"/>
+      <choice name="FXAA" value="FXAA"/>
+      <choice name="LCD PERSISTENCE" value="LCDPersistence"/>
+      <choice name="NATURAL COLORS" value="Natural"/>
+      <choice name="NATURAL COLORS (NO BLUR)" value="NaturalA"/>
+      <choice name="PSP COLOR" value="PSPColor"/>
+      <choice name="SCANLINES" value="Scanlines"/>
+      <choice name="SHARPEN" value="Sharpen"/>
+      <choice name="UPSCALE SPLINE36" value="UpscaleSpline36"/>
+      <choice name="GAUSSIAN (SSAA)" value="SSAA(Gauss)"/>
+      <choice name="VIDEO SMOOTHING AA" value="VideoSmoothingAA"/>
+      <choice name="VIGNETTE" value="Vignette"/>
+    </feature>
     <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="videomode"/>
     <feature submenu="VIDEO" name="FRAMESKIP" group="ADVANCED SETTINGS" value="ppsspp_frame_skipping" description="Skip frames to improve performance (smoothless).">
       <choice name="NO" value="0"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -8161,10 +8161,17 @@
       <choice name="x9" value="9"/>
       <choice name="x10" value="10"/>
     </feature>
+    <feature name="INTERNAL RESOLUTION" group="GENERAL SETTINGS" value="ppsspp_ratio">
+      <choice name="16:9" value="1.000000"/>
+      <choice name="4:3" value="0.750000"/>
+      <choice name="1:1" value="0.562500"/>
+      <choice name="STRETCH" value="stretch"/>
+    </feature>
     <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="ppsspp_vsync">
       <choice name="YES" value="1"/>
       <choice name="NO" value="0"/>
     </feature>
+    <feature name="INTEGER SCALING" group="GENERAL SETTINGS" value="Integer_Scaling" preset="switch"/>
     <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="videomode"/>
     <feature submenu="VIDEO" name="FRAMESKIP" group="ADVANCED SETTINGS" value="ppsspp_frame_skipping" description="Skip frames to improve performance (smoothless).">
       <choice name="NO" value="0"/>

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -281,10 +281,7 @@
       <choice name="ON" value="1"/>
     </feature>
     <feature name="DISCORD RICH PRESENCE" value="global.discord" description="Enable Discord Rich Presence service, this will update Discord status to show the games being played." preset="switch"/>
-    <feature name="DISCORD RICH PRESENCE" value="discord" description="Enable Discord Rich Presence service, this will update Discord status to show the games being played.">
-      <choice name="ON" value="1"/>
-      <choice name="OFF" value="0"/>
-    </feature>
+    <feature name="DISCORD RICH PRESENCE" value="discord" description="Enable Discord Rich Presence service, this will update Discord status to show the games being played." preset="switch"/>
     <feature name="TURBO MODE" value="enable_turbo">
       <choice name="CLASSIC" value="0"/>
       <choice name="TOGGLE" value="1"/>
@@ -307,10 +304,7 @@
       <choice name="RIGHT TRIGGER (R2)" value="7"/>
     </feature>
     <feature name="AUTOCONFIGURE CONTROLLERS" value="global.disableautocontrollers" preset="switchoff"/>
-    <feature name="AUTOCONFIGURE CONTROLLERS" value="disableautocontrollers">
-      <choice name="ON" value="0"/>
-      <choice name="OFF" value="1"/>
-    </feature>
+    <feature name="AUTOCONFIGURE CONTROLLERS" value="disableautocontrollers" preset="switchoff"/>
 	<feature name="KEYBOARD FOCUS" value="GameFocus" description="Disable RetroArch keyboard shortcuts and give full access of Keyboard to the core. Toggle with 'Scroll Lock' key.">
       <choice name="OFF" value="0"/>
       <choice name="ON" value="1"/>
@@ -5826,16 +5820,13 @@
   </emulator>
   <!-- CEMU -->
   <emulator name="cemu" features="padtokeyboard">
-    <sharedFeature group="GENERAL SETTINGS" value="disableautocontrollers"/>
     <sharedFeature group="ADVANCED SETTINGS" value="videomode"/>
     <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="VSync">
       <choice name="NO" value="false"/>
       <choice name="YES" value="true"/>
     </feature>
-    <feature name="GAME ASPECT RATIO" group="GENERAL SETTINGS" value="stretch">
-      <choice name="KEEP ASPECT RATIO" value="0"/>
-      <choice name="STRETCH TO DISPLAY" value="1"/>
-    </feature>
+    <feature name="STRETCH TO DISPLAY" group="GENERAL SETTINGS" value="stretch" preset="switch"/>
+    <sharedFeature group="GENERAL SETTINGS" value="disableautocontrollers"/>
     <feature submenu="EMULATION" name="LANGUAGE" group="ADVANCED SETTINGS" value="wiiu_language">
       <choice name="Japanese" value="0"/>
       <choice name="English" value="1"/>
@@ -5849,7 +5840,7 @@
       <choice name="Português" value="9"/>
       <choice name="Русский (Russian)" value="10"/>
     </feature>
-    <feature submenu="VISUAL RENDERING" name="ASYNCHRONOUS TEXTURE COMPILATION" group="ADVANCED SETTINGS" value="async_texture" description="Can improve performance on more powerful GPUs that have spare headroom. Only works with Vulkan renderer.">
+    <feature submenu="VISUAL RENDERING" name="ASYNCHRONOUS TEXTURE COMPILATION" group="ADVANCED SETTINGS" value="async_texture" description="Can improve performance on more powerful GPUs that have spare headroom. Only works with Vulkan renderer." preset="switch"/>
       <choice name="NO" value="false"/>
       <choice name="YES" value="true"/>
     </feature>
@@ -5950,7 +5941,6 @@
   </emulator>
   <!-- CITRA -->
   <emulator name="citra" features="padtokeyboard">
-    <sharedFeature group="GENERAL SETTINGS" value="ratio"/>  
     <feature name="INTERNAL RESOLUTION" group="GENERAL SETTINGS" value="citra_resolution_factor">
       <choice name="NATIVE (400x240)" value="1"/>
       <choice name="2X (480p)" value="2"/>
@@ -5971,19 +5961,10 @@
       <choice name="LARGE SCREEN / SMALL SCREEN" value="2"/>
       <choice name="SIDE BY SIDE" value="3"/>
     </feature>
-    <feature submenu="VIDEO" group="ADVANCED SETTINGS" name="SWAP SCREEN" value="citra_swap_screen" description="Set the bottom screen as prominent.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="VIDEO" group="ADVANCED SETTINGS" name="SWAP SCREEN" value="citra_swap_screen" description="Set the bottom screen as prominent." preset="switch"/>
     <sharedFeature submenu="VISUAL RENDERING" group="ADVANCED SETTINGS" value="smooth"/>
-    <feature submenu="VISUAL RENDERING" name="CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="citra_custom_textures" description="Replace original textures with custom textures pack.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="VISUAL RENDERING" name="PREFETCH CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="citra_PreloadTextures" description="Preload custom textures on startup.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="VISUAL RENDERING" name="CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="citra_custom_textures" description="Replace original textures with custom textures pack." preset="switch"/>
+    <feature submenu="VISUAL RENDERING" name="PREFETCH CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="citra_PreloadTextures" description="Preload custom textures on startup." preset="switch"/>
     <feature submenu="EMULATION" name="REGION" group="ADVANCED SETTINGS" value="citra_region_value" description="Force the region of the system.">
       <choice name="USA" value="1"/>
       <choice name="EUROPE" value="2"/>
@@ -6008,10 +5989,7 @@
       <choice name="簡化字 (Chinese - traditional)" value="11"/>
     </feature>
     <sharedFeature submenu="USER INTERFACE" group="ADVANCED SETTINGS" value="discord"/>
-    <feature submenu="CONTROLS" name="INVERT A AND B" group="ADVANCED SETTINGS" value="gamepadbuttons" description="Switch A/B &amp; X/Y buttons for XBOX controllers.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="CONTROLS" name="INVERT A AND B" group="ADVANCED SETTINGS" value="gamepadbuttons" description="Switch A/B &amp; X/Y buttons for XBOX controllers." preset="switch"/>
   </emulator>
   <emulator name="citra-canary">
     <sharedFeature group="GENERAL SETTINGS" value="ratio"/>
@@ -8994,11 +8972,6 @@
   </emulator>
   <!-- YUZU -->
   <emulator name="yuzu, yuzu-early-access">
-    <sharedFeature group="GENERAL SETTINGS" value="disableautocontrollers"/>
-    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="use_vsync">
-      <choice name="YES" value="true"/>
-      <choice name="NO" value="false"/>
-    </feature>
     <feature name="INTERNAL RESOLUTION" group="GENERAL SETTINGS" value="resolution_setup" description="Improve fidelity of 3D models at the cost of increased performance requirements.">
       <choice name="0.5x (360p/540p)" value="0"/>
       <choice name="0.75x (540p/810p)" value="1"/>
@@ -9012,15 +8985,18 @@
       <choice name="7x (5040p/7560p)" value="9"/>
       <choice name="8x (5760p/8640p)" value="10"/>
     </feature>
-	<feature submenu="EMULATION" name="REGION" group="ADVANCED SETTINGS" value="yuzu_region_value" description="Force the region of the system.">
-      <choice name="JAPAN" value="0"/>
-      <choice name="USA" value="1"/>
-      <choice name="EUROPE" value="2"/>
-      <choice name="AUSTRALIA" value="3"/>
-      <choice name="CHINA" value="4"/>
-      <choice name="KOREA" value="5"/>
-      <choice name="TAIWAN" value="6"/>
+    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="use_vsync">
+      <choice name="YES" value="true"/>
+      <choice name="NO" value="false"/>
     </feature>
+    <feature name="GAME ASPECT RATIO" group="GENERAL SETTINGS" value="yuzu_ratio">
+      <choice name="DEFAULT" value="0"/>
+      <choice name="FORCE 4/3" value="1"/>
+      <choice name="FORCE 21/9" value="2"/>
+      <choice name="FORCE 16/10" value="3"/>
+      <choice name="STRETCH" value="4"/>
+    </feature>
+    <sharedFeature group="GENERAL SETTINGS" value="disableautocontrollers"/>
 	<feature submenu="EMULATION" name="LANGUAGE" group="ADVANCED SETTINGS" value="yuzu_language">
         <choice name="American English" value="1"/>        
         <choice name="日本語 (Japanese)" value="0"/>
@@ -9041,14 +9017,20 @@
         <choice name="簡化字 (Chinese - traditional)" value="16"/>
         <choice name="Português (Brazil)" value="17"/>
     </feature>
+	<feature submenu="EMULATION" name="REGION" group="ADVANCED SETTINGS" value="yuzu_region_value" description="Force the region of the system.">
+      <choice name="JAPAN" value="0"/>
+      <choice name="USA" value="1"/>
+      <choice name="EUROPE" value="2"/>
+      <choice name="AUSTRALIA" value="3"/>
+      <choice name="CHINA" value="4"/>
+      <choice name="KOREA" value="5"/>
+      <choice name="TAIWAN" value="6"/>
+    </feature>
+	<feature submenu="EMULATION" name="USE UNDOCKED MODE" group="ADVANCED SETTINGS" value="yuzu_undock" description="Can increase performance on some lower-end systems." preset="switch"/>
 	<feature submenu="EMULATION" name="CPU ACCURACY" group="ADVANCED SETTINGS" value="cpu_accuracy" description="Leave AUTO as default except the game requires specific setting.">
       <choice name="ACCURATE" value="1"/>
       <choice name="UNSAFE" value="2"/>
       <choice name="PARANOID" value="3"/>
-    </feature>
-	<feature submenu="EMULATION" name="USE UNDOCKED MODE" group="ADVANCED SETTINGS" value="yuzu_undock" description="Can increase performance on some lower-end systems.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
     </feature>
     <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="videomode"/>
     <feature submenu="VIDEO" name="GPU ACCURACY" group="ADVANCED SETTINGS" value="gpu_accuracy" description="Default is 'HIGH', set to 'NORMAL' to increase performance at the cost of accuracy.">
@@ -9056,10 +9038,7 @@
       <choice name="NORMAL" value="0"/>
       <choice name="EXTREME (VERY SLOW)" value="2"/>
     </feature>
-    <feature submenu="VIDEO" name="USE ASYNCHRONOUS SHADER COMPILATION" group="ADVANCED SETTINGS" value="use_asynchronous_shaders" description="Can reduce lags when compiling shaders, experimental.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="VIDEO" name="USE ASYNCHRONOUS SHADER COMPILATION" group="ADVANCED SETTINGS" value="use_asynchronous_shaders" description="Can reduce lags when compiling shaders, experimental." preset="switch"/>
     <feature submenu="VISUAL RENDERING" name="ANTI ALIASING" group="ADVANCED SETTINGS" value="anti_aliasing" description="Set Anti Aliasing for rendered content.">
       <choice name="NONE" value="0"/>
       <choice name="FXAA" value="1"/>
@@ -9125,14 +9104,8 @@
       <choice name="HANDHELD" value="4"/>
       <choice name="GAMECUBE" value="5"/>
     </feature>
-    <feature submenu="CONTROLS" name="ENABLE MOTION" group="ADVANCED SETTINGS" value="yuzu_enable_motion" description="Can only be used if the controller is compatible with motion control.">
-      <choice name="NO" value="false"/>
-      <choice name="YES" value="true"/>
-    </feature>
-    <feature submenu="CONTROLS" name="INVERT A/B and X/Y BUTTONS" group="ADVANCED SETTINGS" value="yuzu_gamepadbuttons" description="Invert face buttons for XBOX controllers.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="CONTROLS" name="ENABLE MOTION" group="ADVANCED SETTINGS" value="yuzu_enable_motion" description="Can only be used if the controller is compatible with motion control." preset="switch"/>
+    <feature submenu="CONTROLS" name="INVERT A/B and X/Y BUTTONS" group="ADVANCED SETTINGS" value="yuzu_gamepadbuttons" description="Invert face buttons for XBOX controllers." preset="switch"/>
     <sharedFeature submenu="USER INTERFACE" group="ADVANCED SETTINGS" value="discord"/>
   </emulator>
   <!-- ZACCARIA PINBALL -->

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -5791,10 +5791,7 @@
       <choice name="7/3 (2.333)" value="11"/>
       <choice name="STRETCHED" value="stretch"/>
     </feature>
-    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="vsync">
-      <choice name="YES" value="1"/>
-      <choice name="NO" value="0"/>
-    </feature>
+    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="vsync" preset="switchoff"/>
     <feature name="DISPLAY MODE" group="GENERAL SETTINGS" value="displaymode">
       <choice name="BORDERLESS WINDOW" value="0"/>
       <choice name="WINDOWED" value="1"/>
@@ -5813,14 +5810,8 @@
       <choice name="XBR LV2" value="xbr-lv2.dstack"/>
       <choice name="XBR LV3" value="xbr-lv3.dstack"/>
     </feature>
-    <feature name="ENABLE HDR" submenu="VISUAL RENDERING" group="ADVANCED SETTINGS" value="enable_hdr" description="Enable HDR for HDR-compatible displays.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature name="PAL MODE" submenu="EMULATION" group="ADVANCED SETTINGS" value="pal_mode" description="Forces console to PAL mode instead of NTSC, might feel sluggish.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature name="ENABLE HDR" submenu="VISUAL RENDERING" group="ADVANCED SETTINGS" value="enable_hdr" description="Enable HDR for HDR-compatible displays." preset="switch"/>
+    <feature name="PAL MODE" submenu="EMULATION" group="ADVANCED SETTINGS" value="pal_mode" description="Forces console to PAL mode instead of NTSC, might feel sluggish." preset="switch"/>
   </emulator>
   <!-- CEMU -->
   <emulator name="cemu" features="padtokeyboard">
@@ -6020,31 +6011,16 @@
       <choice name="11x" value="11"/>
       <choice name="12x" value="12"/>
     </feature>
-    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="VSync">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="VSync" preset="switchoff"/>
     <feature name="GAME ASPECT RATIO" group="GENERAL SETTINGS" value="ratio">
       <choice name="KEEP ASPECT RATIO" value="true"/>
       <choice name="STRETCHED" value="stretch"/>
     </feature>
     <sharedFeature group="ADVANCED SETTINGS" value="videomode"/>
-	<feature submenu="EMULATION" name="DISABLE XBE SIGNATURE CHECK" group="ADVANCED SETTINGS" value="xbeSignature" description="Disable XBE signature check when using homebrew games.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-	<feature submenu="EMULATION" name="DISABLE PIXEL SHADERS" group="ADVANCED SETTINGS" value="disablePixelShaders" description="Disable pixel shaders can fix some games crashing, do not activate unless the game needs it.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-	<feature submenu="EMULATION" name="USE ALL CORES" group="ADVANCED SETTINGS" value="useallcores" description="Will run the XBOX process on multiple CPU threads, can improve performance but might break some games.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-	<feature submenu="EMULATION" name="SKIP RDTSC PATCHING" group="ADVANCED SETTINGS" value="rdtscPatching">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+	<feature submenu="EMULATION" name="DISABLE XBE SIGNATURE CHECK" group="ADVANCED SETTINGS" value="xbeSignature" description="Disable XBE signature check when using homebrew games." preset="switch"/>
+	<feature submenu="EMULATION" name="DISABLE PIXEL SHADERS" group="ADVANCED SETTINGS" value="disablePixelShaders" description="Disable pixel shaders can fix some games crashing, do not activate unless the game needs it." preset="switch"/>
+	<feature submenu="EMULATION" name="USE ALL CORES" group="ADVANCED SETTINGS" value="useallcores" description="Will run the XBOX process on multiple CPU threads, can improve performance but might break some games." preset="switch"/>
+	<feature submenu="EMULATION" name="SKIP RDTSC PATCHING" group="ADVANCED SETTINGS" value="rdtscPatching" preset="switch"/>
   </emulator>
   <!-- DAPHNE HYPSEUS -->
   <emulator name="daphne">
@@ -6060,10 +6036,7 @@
       <choice name="NO" value="0"/>
       <choice name="YES" value="1"/>
     </feature>-->
-    <feature group="ADVANCED SETTINGS" name="FASTBOOT" value="fastboot">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature group="ADVANCED SETTINGS" name="FASTBOOT" value="fastboot" preset="switch"/>
   </emulator>
   <emulator name="hypseus" features="padtokeyboard">
     <sharedFeature group="GENERAL SETTINGS" value="shaderset"/>
@@ -6104,10 +6077,7 @@
       <choice name="5x" value="5"/>
       <choice name="6x" value="6"/>
     </feature>
-    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="VSync">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="VSync" preset="switchoff"/>
     <feature name="GAME ASPECT RATIO" group="GENERAL SETTINGS" value="demul_ratio">
       <choice name="16/9" value="2"/>
       <choice name="4/3" value="1"/>
@@ -6155,10 +6125,7 @@
       <choice name="5x" value="5"/>
       <choice name="6x" value="6"/>
     </feature>
-    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="VSync">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature name="VERTICAL SYNC" group="GENERAL SETTINGS" value="VSync" preset="switchoff"/>
     <feature name="GAME ASPECT RATIO" group="GENERAL SETTINGS" value="demul_ratio">
       <choice name="16/9" value="2"/>
       <choice name="4/3" value="1"/>
@@ -6206,10 +6173,7 @@
       <!-- ADVANCED SETTINGS -->
       <!-- VIDEO -->
       <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="videomode"/>
-      <feature submenu="VIDEO" name="WIDESCREEN" group="ADVANCED SETTINGS" value="widescreen_hack" description="Display the emulated framebuffer at a widescreen aspect ratio. Get best results with full 3D games.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="VIDEO" name="WIDESCREEN" group="ADVANCED SETTINGS" value="widescreen_hack" description="Display the emulated framebuffer at a widescreen aspect ratio. Get best results with full 3D games." preset="switch"/>
       <feature submenu="VIDEO" name="COMPILE SHADERS BEFORE STARTING" group="ADVANCED SETTINGS" value="WaitForShadersBeforeStarting" description="May reduce stuttering a the cost of longuer delay to start a game.">
         <choice name="NO" value="False"/>
         <choice name="YES" value="True"/>
@@ -6241,14 +6205,8 @@
         <choice name="NO" value="False"/>
         <choice name="YES" value="True"/>
       </feature>
-      <feature submenu="VISUAL RENDERING" name="CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="hires_textures" description="Replace original textures with custom textures pack.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="VISUAL RENDERING" name="PREFETCH CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="CacheHiresTextures" description="Cache custom textures to system RAM on startup.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="VISUAL RENDERING" name="CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="hires_textures" description="Replace original textures with custom textures pack." preset="switch"/>
+      <feature submenu="VISUAL RENDERING" name="PREFETCH CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="CacheHiresTextures" description="Cache custom textures to system RAM on startup." preset="switch"/>
       <!-- EMULATION -->
       <feature submenu="EMULATION" name="LANGUAGE" group="ADVANCED SETTINGS" value="gamecube_language" order="88">
         <choice name="Deutsch" value="1"/>
@@ -6258,26 +6216,11 @@
         <choice name="Italiano" value="4"/>
         <choice name="Nederlands" value="5"/>
       </feature>
-      <feature submenu="EMULATION" name="SKIP BIOS" group="ADVANCED SETTINGS" value="skip_bios" description="Skips the BIOS boot animation displayed when loading content." order="88">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="EMULATION" name="ENABLE CHEATS" group="ADVANCED SETTINGS" value="enable_cheats" description="Enable the effects of the chosen Action Replay and Gecko codes for a game." order="89">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="EMULATION" name="MEMORY MANAGEMENT UNIT" group="ADVANCED SETTINGS" value="enable_mmu" description="Enable the Memory Management Unit. Required for some games." order="89">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="EMULATION" name="DUAL CORE CPU THREAD" group="ADVANCED SETTINGS" value="CPUThread" description="Run games faster. A powerful option for gaining performance that has no downsides some of the time. May cause various random issues caused by splitting the CPU and GPU threads onto different cores." order="89">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="EMULATION" name="FAST DISK SPEED" group="ADVANCED SETTINGS" value="enable_fastdisc" description="Improve the loading of discs of the emulated game." order="89">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="EMULATION" name="SKIP BIOS" group="ADVANCED SETTINGS" value="skip_bios" description="Skips the BIOS boot animation displayed when loading content." order="88" preset="switch"/>
+      <feature submenu="EMULATION" name="ENABLE CHEATS" group="ADVANCED SETTINGS" value="enable_cheats" description="Enable the effects of the chosen Action Replay and Gecko codes for a game." order="89" preset="switch"/>
+      <feature submenu="EMULATION" name="MEMORY MANAGEMENT UNIT" group="ADVANCED SETTINGS" value="enable_mmu" description="Enable the Memory Management Unit. Required for some games." order="89" preset="switch"/>
+      <feature submenu="EMULATION" name="DUAL CORE CPU THREAD" group="ADVANCED SETTINGS" value="CPUThread" description="Run games faster. A powerful option for gaining performance that has no downsides some of the time. May cause various random issues caused by splitting the CPU and GPU threads onto different cores." order="89" preset="switch"/>
+      <feature submenu="EMULATION" name="FAST DISK SPEED" group="ADVANCED SETTINGS" value="enable_fastdisc" description="Improve the loading of discs of the emulated game." order="89" preset="switch"/>
       <feature submenu="EMULATION" name="SKIP EFB ACCESS (HACK)" group="ADVANCED SETTINGS" value="EFBEmulateFormatChanges" description="Improve performance in some games but can disable graphical effects and gameplay related features." order="89">
         <choice name="NO" value="False"/>
         <choice name="YES" value="True"/>
@@ -6295,19 +6238,10 @@
         <choice name="YES" value="True"/>
         <choice name="NO" value="False"/>
       </feature>
-      <feature submenu="EMULATION" name="PERFORMANCE MODE" group="ADVANCED SETTINGS" value="perf_hacks" description="Improves the emulation performance at the cost of accuracy." order="89">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="EMULATION" name="PERFORMANCE MODE" group="ADVANCED SETTINGS" value="perf_hacks" description="Improves the emulation performance at the cost of accuracy." order="89" preset="switch"/>
       <!-- USER INTERFACE -->
-      <feature submenu="USER INTERFACE" name="NOTIFICATIONS" group="ADVANCED SETTINGS" value="OnScreenDisplayMessages" description="Display or not on-screen notifications." order="90">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="USER INTERFACE" name="SHOW FPS" group="ADVANCED SETTINGS" value="DrawFramerate" description="Shows the number of frames redered per seconds as a measure of emulation speed." order="90">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="USER INTERFACE" name="NOTIFICATIONS" group="ADVANCED SETTINGS" value="OnScreenDisplayMessages" description="Display or not on-screen notifications." order="90" preset="switch"/>
+      <feature submenu="USER INTERFACE" name="SHOW FPS" group="ADVANCED SETTINGS" value="DrawFramerate" description="Shows the number of frames redered per seconds as a measure of emulation speed." order="90" preset="switch"/>
       <sharedFeature submenu="USER INTERFACE" group="ADVANCED SETTINGS" value="discord" order="91"/>
       <!-- DRIVERS -->
       <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="gfxbackend" description="Select which graphics API to use internally.">
@@ -6317,26 +6251,11 @@
         <choice name="DIRECTX 12" value="D3D12"/>
       </feature>
       <!-- CONTROLS -->
-      <feature submenu="CONTROLS" name="PLAYER 1 USE GAMECUBE ADAPTER" group="ADVANCED SETTINGS" value="gamecubepad0" description="Select when controller is a real Gamecube pad connected to a gamecube adapter.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="CONTROLS" name="PLAYER 2 USE GAMECUBE ADAPTER" group="ADVANCED SETTINGS" value="gamecubepad1" description="Select when controller is a real Gamecube pad connected to a gamecube adapter.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="CONTROLS" name="PLAYER 3 USE GAMECUBE ADAPTER" group="ADVANCED SETTINGS" value="gamecubepad2" description="Select when controller is a real Gamecube pad connected to a gamecube adapter.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="CONTROLS" name="PLAYER 4 USE GAMECUBE ADAPTER" group="ADVANCED SETTINGS" value="gamecubepad3" description="Select when controller is a real Gamecube pad connected to a gamecube adapter.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="CONTROLS" name="INVERT A AND B" group="ADVANCED SETTINGS" value="gamepadbuttons" description="Invert A/B and X/Y buttons.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="CONTROLS" name="PLAYER 1 USE GAMECUBE ADAPTER" group="ADVANCED SETTINGS" value="gamecubepad0" description="Select when controller is a real Gamecube pad connected to a gamecube adapter." preset="switch"/>
+      <feature submenu="CONTROLS" name="PLAYER 2 USE GAMECUBE ADAPTER" group="ADVANCED SETTINGS" value="gamecubepad1" description="Select when controller is a real Gamecube pad connected to a gamecube adapter." preset="switch"/>
+      <feature submenu="CONTROLS" name="PLAYER 3 USE GAMECUBE ADAPTER" group="ADVANCED SETTINGS" value="gamecubepad2" description="Select when controller is a real Gamecube pad connected to a gamecube adapter." preset="switch"/>
+      <feature submenu="CONTROLS" name="PLAYER 4 USE GAMECUBE ADAPTER" group="ADVANCED SETTINGS" value="gamecubepad3" description="Select when controller is a real Gamecube pad connected to a gamecube adapter." preset="switch"/>
+      <feature submenu="CONTROLS" name="INVERT A AND B" group="ADVANCED SETTINGS" value="gamepadbuttons" description="Invert A/B and X/Y buttons." preset="switch"/>
     </system>
     <!-- wii -->
     <system name="wii">
@@ -6365,10 +6284,7 @@
       <!-- ADVANCED SETTINGS -->
       <!-- VIDEO -->
       <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="videomode"/>
-      <feature submenu="VIDEO" name="WIDESCREEN" group="ADVANCED SETTINGS" value="widescreen_hack" description="Display the emulated framebuffer at a widescreen aspect ratio. Get best results with full 3D games.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="VIDEO" name="WIDESCREEN" group="ADVANCED SETTINGS" value="widescreen_hack" description="Display the emulated framebuffer at a widescreen aspect ratio. Get best results with full 3D games." preset="switch"/>
       <feature submenu="VIDEO" name="COMPILE SHADERS BEFORE STARTING" group="ADVANCED SETTINGS" value="WaitForShadersBeforeStarting" description="May reduce stuttering a the cost of longuer delay to start a game.">
         <choice name="NO" value="False"/>
         <choice name="YES" value="True"/>
@@ -6400,14 +6316,8 @@
         <choice name="NO" value="False"/>
         <choice name="YES" value="True"/>
       </feature>
-      <feature submenu="VISUAL RENDERING" name="CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="hires_textures" description="Replace original textures with custom textures pack.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="VISUAL RENDERING" name="PREFETCH CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="CacheHiresTextures" description="Cache custom textures to system RAM on startup.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="VISUAL RENDERING" name="CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="hires_textures" description="Replace original textures with custom textures pack." preset="switch"/>
+      <feature submenu="VISUAL RENDERING" name="PREFETCH CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="CacheHiresTextures" description="Cache custom textures to system RAM on startup." preset="switch"/>
       <!-- EMULATION -->
       <feature submenu="EMULATION" name="LANGUAGE" group="ADVANCED SETTINGS" value="wii_language">
         <choice name="Deutsch" value="2"/>
@@ -6418,22 +6328,10 @@
         <choice name="Nederlands" value="6"/>
         <choice name="Japanese" value="0"/>
       </feature>
-      <feature submenu="EMULATION" name="ENABLE CHEATS" group="ADVANCED SETTINGS" value="enable_cheats" description="Enable the effects of the chosen Action Replay and Gecko codes for a game.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="EMULATION" name="MEMORY MANAGEMENT UNIT" group="ADVANCED SETTINGS" value="enable_mmu" description="Enable the Memory Management Unit. Required for some games.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="EMULATION" name="DUAL CORE CPU THREAD" group="ADVANCED SETTINGS" value="CPUThread" description="Run games faster. A powerful option for gaining performance that has no downsides some of the time. May cause various random issues caused by splitting the CPU and GPU threads onto different cores.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="EMULATION" name="FAST DISK SPEED" group="ADVANCED SETTINGS" value="enable_fastdisc" description="Improve the loading of discs of the emulated game.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="EMULATION" name="ENABLE CHEATS" group="ADVANCED SETTINGS" value="enable_cheats" description="Enable the effects of the chosen Action Replay and Gecko codes for a game." preset="switch"/>
+      <feature submenu="EMULATION" name="MEMORY MANAGEMENT UNIT" group="ADVANCED SETTINGS" value="enable_mmu" description="Enable the Memory Management Unit. Required for some games." preset="switch"/>
+      <feature submenu="EMULATION" name="DUAL CORE CPU THREAD" group="ADVANCED SETTINGS" value="CPUThread" description="Run games faster. A powerful option for gaining performance that has no downsides some of the time. May cause various random issues caused by splitting the CPU and GPU threads onto different cores." preset="switch"/>
+      <feature submenu="EMULATION" name="FAST DISK SPEED" group="ADVANCED SETTINGS" value="enable_fastdisc" description="Improve the loading of discs of the emulated game." preset="switch"/>
       <feature submenu="EMULATION" name="SKIP EFB ACCESS (HACK)" group="ADVANCED SETTINGS" value="EFBEmulateFormatChanges" description="Improve performance in some games but can disable graphical effects and gameplay related features.">
         <choice name="NO" value="False"/>
         <choice name="YES" value="True"/>
@@ -6451,19 +6349,10 @@
         <choice name="YES" value="True"/>
         <choice name="NO" value="False"/>
       </feature>
-      <feature submenu="EMULATION" name="PERFORMANCE MODE" group="ADVANCED SETTINGS" value="perf_hacks" description="Improves the emulation performance at the cost of accuracy.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="EMULATION" name="PERFORMANCE MODE" group="ADVANCED SETTINGS" value="perf_hacks" description="Improves the emulation performance at the cost of accuracy." preset="switch"/>
       <!-- USER INTERFACE -->
-      <feature submenu="USER INTERFACE" name="NOTIFICATIONS" group="ADVANCED SETTINGS" value="OnScreenDisplayMessages" description="Display or not on-screen notifications.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
-      <feature submenu="USER INTERFACE" name="SHOW FPS" group="ADVANCED SETTINGS" value="DrawFramerate" description="Shows the number of frames redered per seconds as a measure of emulation speed.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="USER INTERFACE" name="NOTIFICATIONS" group="ADVANCED SETTINGS" value="OnScreenDisplayMessages" description="Display or not on-screen notifications." preset="switch"/>
+      <feature submenu="USER INTERFACE" name="SHOW FPS" group="ADVANCED SETTINGS" value="DrawFramerate" description="Shows the number of frames redered per seconds as a measure of emulation speed." preset="switch"/>
       <sharedFeature submenu="USER INTERFACE" group="ADVANCED SETTINGS" value="discord"/>
       <!-- DRIVERS -->
       <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="gfxbackend" description="Select which graphics API to use internally.">
@@ -6473,10 +6362,7 @@
         <choice name="DIRECTX 12" value="D3D12"/>
       </feature>
       <!-- CONTROLS -->
-      <feature submenu="CONTROLS" name="INVERT A AND B" group="ADVANCED SETTINGS" value="gamepadbuttons" description="Invert A/B and X/Y buttons.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="CONTROLS" name="INVERT A AND B" group="ADVANCED SETTINGS" value="gamepadbuttons" description="Invert A/B and X/Y buttons." preset="switch"/>
       <feature submenu="CONTROLS" name="WIIMOTE TYPE" group="ADVANCED SETTINGS" value="emulatedwiimotes">
         <choice name="EMULATED" value="1"/>
         <choice name="REAL" value="0"/>
@@ -6501,10 +6387,7 @@
         <choice name="BOTTOM" value="0"/>
         <choice name="TOP" value="1"/>
       </feature>
-      <feature submenu="CONTROLS" name="USE GAMECUBE CONTROLLERS" group="ADVANCED SETTINGS" value="wii_gamecube">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-      </feature>
+      <feature submenu="CONTROLS" name="USE GAMECUBE CONTROLLERS" group="ADVANCED SETTINGS" value="wii_gamecube" preset="switch"/>
     </system>
   </emulator>
   <!-- DOLPHIN TRIFORCE -->
@@ -6532,10 +6415,7 @@
 	<sharedFeature group="GENERAL SETTINGS" value="disableautocontrollers"/>
     <sharedFeature group="ADVANCED SETTINGS" value="videomode"/>
 	<!-- VIDEO -->
-	<feature submenu="VIDEO" name="WIDESCREEN" group="ADVANCED SETTINGS" value="widescreen_hack" description="Display the emulated framebuffer at a widescreen aspect ratio. Get best results with full 3D games.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+	<feature submenu="VIDEO" name="WIDESCREEN" group="ADVANCED SETTINGS" value="widescreen_hack" description="Display the emulated framebuffer at a widescreen aspect ratio. Get best results with full 3D games." preset="switch"/>
     <feature submenu="VIDEO" name="COMPILE SHADERS BEFORE STARTING" group="ADVANCED SETTINGS" value="WaitForShadersBeforeStarting" description="May reduce stuttering a the cost of longuer delay to start a game.">
       <choice name="NO" value="False"/>
       <choice name="YES" value="True"/>
@@ -6567,14 +6447,8 @@
       <choice name="NO" value="False"/>
       <choice name="YES" value="True"/>
     </feature>
-    <feature submenu="VISUAL RENDERING" name="CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="hires_textures" description="Replace original textures with custom textures pack.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="VISUAL RENDERING" name="PREFETCH CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="CacheHiresTextures" description="Cache custom textures to system RAM on startup.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="VISUAL RENDERING" name="CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="hires_textures" description="Replace original textures with custom textures pack." preset="switch"/>
+    <feature submenu="VISUAL RENDERING" name="PREFETCH CUSTOM TEXTURES" group="ADVANCED SETTINGS" value="CacheHiresTextures" description="Cache custom textures to system RAM on startup." preset="switch"/>
 	<!-- EMULATION -->
 	<feature submenu="EMULATION" name="LANGUAGE" group="ADVANCED SETTINGS" value="gamecube_language" order="88">
       <choice name="Deutsch" value="1"/>
@@ -6584,26 +6458,11 @@
       <choice name="Italiano" value="4"/>
       <choice name="Nederlands" value="5"/>
     </feature>
-    <feature submenu="EMULATION" name="SKIP BIOS" group="ADVANCED SETTINGS" value="skip_bios" description="Skips the BIOS boot animation displayed when loading content.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-	<feature submenu="EMULATION" name="ENABLE CHEATS" group="ADVANCED SETTINGS" value="enable_cheats" description="Enable the effects of the chosen Action Replay and Gecko codes for a game." order="89">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-	<feature submenu="EMULATION" name="MEMORY MANAGEMENT UNIT" group="ADVANCED SETTINGS" value="enable_mmu" description="Enable the Memory Management Unit. Required for some games." order="89">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="EMULATION" name="DUAL CORE CPU THREAD" group="ADVANCED SETTINGS" value="CPUThread" description="Run games faster. A powerful option for gaining performance that has no downsides some of the time. May cause various random issues caused by splitting the CPU and GPU threads onto different cores.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="EMULATION" name="FAST DISK SPEED" group="ADVANCED SETTINGS" value="enable_fastdisc" description="Improve the loading of discs of the emulated game.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="EMULATION" name="SKIP BIOS" group="ADVANCED SETTINGS" value="skip_bios" description="Skips the BIOS boot animation displayed when loading content." preset="switch"/>
+	<feature submenu="EMULATION" name="ENABLE CHEATS" group="ADVANCED SETTINGS" value="enable_cheats" description="Enable the effects of the chosen Action Replay and Gecko codes for a game." order="89" preset="switch"/>
+	<feature submenu="EMULATION" name="MEMORY MANAGEMENT UNIT" group="ADVANCED SETTINGS" value="enable_mmu" description="Enable the Memory Management Unit. Required for some games." order="89" preset="switch"/>
+    <feature submenu="EMULATION" name="DUAL CORE CPU THREAD" group="ADVANCED SETTINGS" value="CPUThread" description="Run games faster. A powerful option for gaining performance that has no downsides some of the time. May cause various random issues caused by splitting the CPU and GPU threads onto different cores." preset="switch"/>
+    <feature submenu="EMULATION" name="FAST DISK SPEED" group="ADVANCED SETTINGS" value="enable_fastdisc" description="Improve the loading of discs of the emulated game." preset="switch"/>
     <feature submenu="EMULATION" name="SKIP EFB ACCESS (HACK)" group="ADVANCED SETTINGS" value="EFBEmulateFormatChanges" description="Improve performance in some games but can disable graphical effects and gameplay related features.">
       <choice name="NO" value="False"/>
       <choice name="YES" value="True"/>
@@ -6621,19 +6480,10 @@
       <choice name="YES" value="True"/>
       <choice name="NO" value="False"/>
     </feature>
-    <feature submenu="EMULATION" name="PERFORMANCE MODE" group="ADVANCED SETTINGS" value="perf_hacks" description="Improves the emulation performance at the cost of accuracy.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="EMULATION" name="PERFORMANCE MODE" group="ADVANCED SETTINGS" value="perf_hacks" description="Improves the emulation performance at the cost of accuracy." preset="switch"/>
     <!-- USER INTERFACE -->
-    <feature submenu="USER INTERFACE" name="NOTIFICATIONS" group="ADVANCED SETTINGS" value="OnScreenDisplayMessages" description="Display or not on-screen notifications.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="USER INTERFACE" name="SHOW FPS" group="ADVANCED SETTINGS" value="DrawFramerate" description="Shows the number of frames redered per seconds as a measure of emulation speed." order="90">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="USER INTERFACE" name="NOTIFICATIONS" group="ADVANCED SETTINGS" value="OnScreenDisplayMessages" description="Display or not on-screen notifications." preset="switch"/>
+    <feature submenu="USER INTERFACE" name="SHOW FPS" group="ADVANCED SETTINGS" value="DrawFramerate" description="Shows the number of frames redered per seconds as a measure of emulation speed." order="90" preset="switch"/>
     <sharedFeature submenu="USER INTERFACE" group="ADVANCED SETTINGS" value="discord"/>
     <!-- DRIVERS -->
     <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="gfxbackend" description="Select which graphics API to use internally." order="90">
@@ -6643,19 +6493,13 @@
       <choice name="DIRECTX 12" value="D3D12"/>
     </feature>
     <!-- CONTROLS -->
-    <feature submenu="CONTROLS" name="INVERT A AND B" group="ADVANCED SETTINGS" value="gamepadbuttons" description="Invert A/B and X/Y buttons.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="CONTROLS" name="INVERT A AND B" group="ADVANCED SETTINGS" value="gamepadbuttons" description="Invert A/B and X/Y buttons." preset="switch"/>
   </emulator>
   <!-- DOSBOX -->
   <emulator name="dosbox" features="padtokeyboard">
     <sharedFeature group="GENERAL SETTINGS" value="ratio"/>
     <sharedFeature group="ADVANCED SETTINGS" value="videomode"/>
-	<feature submenu="VIDEO" name="WIDESCREEN" group="ADVANCED SETTINGS" value="widescreen_hack" description="Display the emulated framebuffer at a widescreen aspect ratio. Get best results with full 3D games.">
-        <choice name="NO" value="0"/>
-        <choice name="YES" value="1"/>
-    </feature>
+	<feature submenu="VIDEO" name="WIDESCREEN" group="ADVANCED SETTINGS" value="widescreen_hack" description="Display the emulated framebuffer at a widescreen aspect ratio. Get best results with full 3D games." preset="switch"/>
       <feature submenu="VIDEO" name="COMPILE SHADERS BEFORE STARTING" group="ADVANCED SETTINGS" value="WaitForShadersBeforeStarting" description="May reduce stuttering a the cost of longuer delay to start a game.">
         <choice name="NO" value="False"/>
         <choice name="YES" value="True"/>
@@ -6727,10 +6571,7 @@
       <choice name="NO" value="false"/>
       <choice name="YES" value="true"/>
     </feature>
-    <feature submenu="VIDEO" name="DISABLE FULLSCREEN" group="ADVANCED SETTINGS" value="disable_fullscreen" description="Use this option if duckstation is not displaying on the correct monitor.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="VIDEO" name="DISABLE FULLSCREEN" group="ADVANCED SETTINGS" value="disable_fullscreen" description="Use this option if duckstation is not displaying on the correct monitor." preset="switch"/>
     <feature submenu="VISUAL RENDERING" name="TEXTURES FILTERING" group="ADVANCED SETTINGS" value="Texture_Enhancement" description="Smooths out the blockyness of magnified textures on 3D objects by using filtering.">
       <choice name="Nearest Neighbor" value="Nearest"/>
       <choice name="Bilinear" value="Bilinear"/>
@@ -6740,10 +6581,7 @@
       <choice name="xBR" value="xBR"/>
       <choice name="xBR (No Edge Blending)" value="xBRBinAlpha"/>
     </feature>
-    <feature submenu="VISUAL RENDERING" name="TEXTURE CORRECTION" group="ADVANCED SETTINGS" value="pgxp" description="Eliminates distortion and warping of textures when upscaling.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="VISUAL RENDERING" name="TEXTURE CORRECTION" group="ADVANCED SETTINGS" value="pgxp" description="Eliminates distortion and warping of textures when upscaling." preset="switch"/>
     <feature submenu="VISUAL RENDERING" name="SCALED DITHERING" group="ADVANCED SETTINGS" value="Scaled_Dithering" description="Scales the dithern pattern to the resolution scale of the emulated GPU.">
       <choice name="NO" value="false"/>
       <choice name="YES" value="true"/>
@@ -6761,10 +6599,7 @@
       <choice name="FPS ONLY" value="simple"/>
       <choice name="DETAILED" value="detailed"/>
     </feature>
-    <feature submenu="EMULATION" name="SKIP BIOS" group="ADVANCED SETTINGS" value="fullboot" description="Skips the BIOS boot animation displayed when loading content.">
-      <choice name="YES" value="0"/>
-      <choice name="NO" value="1"/>
-    </feature>
+    <feature submenu="EMULATION" name="SHOW BIOS (FULLBOOT)" group="ADVANCED SETTINGS" value="fullboot" description="Show the BIOS boot animation displayed when loading content." preset="switch"/>
     <feature submenu="EMULATION" name="CONSOLE REGION" group="ADVANCED SETTINGS" value="psx_region">
       <choice name="PAL" value="PAL"/>
       <choice name="NTSC US" value="NTSC-U"/>
@@ -6800,10 +6635,7 @@
       <choice name="9" value="9"/>
       <choice name="10" value="10"/>
     </feature>
-    <feature submenu="USER INTERFACE" name="OSD MESSAGES" group="ADVANCED SETTINGS" value="duckstation_osd_enabled" description="Show emulator notifications.">
-      <choice name="YES" value="1"/>
-	  <choice name="NO" value="0"/>
-    </feature>
+    <feature submenu="USER INTERFACE" name="OSD MESSAGES" group="ADVANCED SETTINGS" value="duckstation_osd_enabled" description="Show emulator notifications." preset="switchoff"/>
     <sharedFeature submenu="USER INTERFACE" group="ADVANCED SETTINGS" value="discord"/>
     <feature submenu="CONTROLS" name="CONTROLLER TYPE PLAYER 1" value="duck_controller1" group="ADVANCED SETTINGS">
       <choice name="DUALSHOCK" value="AnalogController"/>
@@ -6901,10 +6733,7 @@
       <choice name="NO" value="0"/>
     </feature>
     <sharedFeature submenu="VIDEO" group="ADVANCED SETTINGS" value="MonitorIndex"/>
-    <feature submenu="VIDEO" name="TRIPLE BUFFERING" group="ADVANCED SETTINGS" value="triplebuffer">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="VIDEO" name="TRIPLE BUFFERING" group="ADVANCED SETTINGS" value="triplebuffer" preset="switch"/>
     <feature submenu="VIDEO" name="ROTATE SCREEN" group="ADVANCED SETTINGS" value="mame_rotate">
       <choice name="NO" value="off"/>
       <choice name="CLOCKWISE" value="autoror"/>
@@ -6977,18 +6806,9 @@
     </feature>
     <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="autosave"/>
     <sharedFeature submenu="EMULATION" group="ADVANCED SETTINGS" value="rewind"/>
-    <feature submenu="EMULATION" name="ENABLE CHEATS" group="ADVANCED SETTINGS" value="mame_cheats" description="Cheats need to be placed in 'bios\mame' folder.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="EMULATION" name="ENABLE HISCORES" group="ADVANCED SETTINGS" value="mame_hiscore" description="Saves the hiscores in supported games.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="EMULATION" name="DISABLE THROTTLE" group="ADVANCED SETTINGS" value="mame_throttle" description="When throttling is disabled, MAME runs the emulation as fast as possible.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="EMULATION" name="ENABLE CHEATS" group="ADVANCED SETTINGS" value="mame_cheats" description="Cheats need to be placed in 'bios\mame' folder." preset="switch"/>
+    <feature submenu="EMULATION" name="ENABLE HISCORES" group="ADVANCED SETTINGS" value="mame_hiscore" description="Saves the hiscores in supported games." preset="switch"/>
+    <feature submenu="EMULATION" name="DISABLE THROTTLE" group="ADVANCED SETTINGS" value="mame_throttle" description="When throttling is disabled, MAME runs the emulation as fast as possible." preset="switch"/>
     <feature submenu="EMULATION" name="READ INI FILE" group="ADVANCED SETTINGS" value="read_ini" description="Read the ini file in 'bios\mame\ini' folder." preset="switch"/>
     <feature submenu="DRIVERS" name="VIDEO" group="ADVANCED SETTINGS" value="mame_video_driver">
       <choice name="D3D" value="d3d"/>
@@ -7029,18 +6849,9 @@
       <choice name="MOUSE" value="mouse"/>
       <choice name="LIGHTGUN" value="lightgun"/>
     </feature>
-    <feature submenu="CONTROLS" name="ENABLE MOUSE" group="ADVANCED SETTINGS" value="mame_mouse" description="Enable mouse input for trackballs, spinners, and similar controls.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="CONTROLS" name="MULTI-MOUSE" group="ADVANCED SETTINGS" value="mame_multimouse" description="Turning this option on will enable MAME to report mouse movement and button presses on different mice independently.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
-    <feature submenu="CONTROLS" name="GUN RELOAD WITH BUTTON" group="ADVANCED SETTINGS" value="mame_offscreen_reload" description="Turn this on when using a lightgun that does not support offscreen reload.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="CONTROLS" name="ENABLE MOUSE" group="ADVANCED SETTINGS" value="mame_mouse" description="Enable mouse input for trackballs, spinners, and similar controls." preset="switch"/>
+    <feature submenu="CONTROLS" name="MULTI-MOUSE" group="ADVANCED SETTINGS" value="mame_multimouse" description="Turning this option on will enable MAME to report mouse movement and button presses on different mice independently." preset="switch"/>
+    <feature submenu="CONTROLS" name="GUN RELOAD WITH BUTTON" group="ADVANCED SETTINGS" value="mame_offscreen_reload" description="Turn this on when using a lightgun that does not support offscreen reload." preset="switch"/>
       <system name="adam" features="padtokeyboard">
         <feature submenu="EMULATION" name="FORCE SOFTLIST" group="ADVANCED SETTINGS" value="force_softlist" description="Force usage of a specific softlist, software list needs to be in 'bios\mame\hash' folder.">
           <choice name="No" value="none"/>
@@ -7338,14 +7149,8 @@
           <choice name="Cassette 2" value="cass2"/>
           <choice name="Cartridge" value="cart"/>
         </feature>
-        <feature submenu="EMULATION" name="32K RAM EXPANSION" group="ADVANCED SETTINGS" value="ti99_32kram" description="32k RAM expansion card installed.">
-          <choice name="YES" value="1"/>
-          <choice name="NO" value="0"/>
-        </feature>
-        <feature submenu="EMULATION" name="SPEECH MODULE" group="ADVANCED SETTINGS" value="ti99_speech" description="Speech module installed.">
-          <choice name="YES" value="1"/>
-          <choice name="NO" value="0"/>
-        </feature>
+        <feature submenu="EMULATION" name="32K RAM EXPANSION" group="ADVANCED SETTINGS" value="ti99_32kram" description="32k RAM expansion card installed." preset="switchoff"/>
+        <feature submenu="EMULATION" name="SPEECH MODULE" group="ADVANCED SETTINGS" value="ti99_speech" description="Speech module installed." preset="switchoff"/>
       </system>
       <system name="tutor" features="padtokeyboard">
         <feature submenu="EMULATION" name="FORCE SOFTLIST" group="ADVANCED SETTINGS" value="force_softlist" description="Force usage of a specific softlist, software list needs to be in 'bios\mame\hash' folder.">
@@ -7448,10 +7253,7 @@
       <choice name="OPENGL" value="0"/>
       <choice name="SOFTWARE" value="1"/>
     </feature>
-    <feature submenu="USER INTERFACE" name="DISPLAY FPS" value="mgba_fps" group="ADVANCED SETTINGS" description="Show FPS overlay in-game.">
-      <choice name="NO" value="0"/>
-      <choice name="YES" value="1"/>
-    </feature>
+    <feature submenu="USER INTERFACE" name="DISPLAY FPS" value="mgba_fps" group="ADVANCED SETTINGS" description="Show FPS overlay in-game." preset="switch"/>
     <sharedFeature submenu="USER INTERFACE" group="ADVANCED SETTINGS" value="discord"/>
   </emulator>
   <!-- MODEL2 -->

--- a/.emulationstation/es_features.cfg
+++ b/.emulationstation/es_features.cfg
@@ -8472,6 +8472,28 @@
       <choice name="KOREA" value="SCEK"/>
       <choice name="SOUTHEAST ASIA" value="SCEH"/>
     </feature>
+    <feature submenu="EMULATION" name="LANGUAGE" group="ADVANCED SETTINGS" value="ps3_language">
+      <choice name="English (US)" value="English (US)"/>
+      <choice name="Français" value="French"/>
+      <choice name="Deutsch" value="German"/>
+      <choice name="Español" value="Spanish"/>
+      <choice name="Italiano" value="Italian"/>
+      <choice name="Nederlands" value="Dutch"/>
+      <choice name="Polski" value="Polish"/>
+      <choice name="Portugues" value="Portuguese (Portugal)"/>
+      <choice name="Portugues do Brasil" value="Portuguese (Brazil)"/>
+      <choice name="日本語 (Japanese)" value="Japanese"/>
+      <choice name="简化字 (Chinese - simplified)" value="Chinese (Simplified)"/>
+      <choice name="簡化字 (Chinese - traditional)" value="Chinese (Traditional)"/>
+      <choice name="한국어 (Korean)" value="Korean"/>
+      <choice name="English (UK)" value="English (UK)"/>
+      <choice name="Dansk" value="Danish"/>
+      <choice name="Suomalainen" value="Finnish"/>
+      <choice name="Svenska" value="Swedish"/>
+      <choice name="Norsk" value="Norwegian"/>
+      <choice name="Türkçe" value="Turkish"/>
+      <choice name="Русский" value="Russian"/>
+    </feature>
     <feature submenu="EMULATION" name="PPU DECODER" group="ADVANCED SETTINGS" value="ppudecoder" description="LLVM is fastest, use the Interpreter settings if there are issues.">
       <choice name="LLVM Recompiler" value="Recompiler (LLVM)"/>
       <choice name="Interpreter (static)" value="Interpreter (static)"/>
@@ -8597,6 +8619,26 @@
       <choice name="CHINA" value="China"/>
       <choice name="KOREA" value="Korea"/>
       <choice name="TAIWAN" value="Taiwan"/>
+    </feature>
+    <feature submenu="EMULATION" name="LANGUAGE" group="ADVANCED SETTINGS" value="switch_language">
+      <choice name="English (US)" value="AmericanEnglish"/>
+      <choice name="Français" value="French"/>
+      <choice name="Deutsch" value="German"/>
+      <choice name="Español" value="Spanish"/>
+      <choice name="Italiano" value="Italian"/>
+      <choice name="Nederlands" value="Dutch"/>
+      <choice name="Portugues" value="Portuguese"/>
+      <choice name="Portugues do Brasil" value="BrazilianPortuguese"/>
+      <choice name="日本語 (Japanese)" value="Japanese"/>
+      <choice name="简化字 (Chinese)" value="Chinese"/>
+      <choice name="简化字 (Chinese - simplified)" value="SimplifiedChinese"/>
+      <choice name="簡化字 (Chinese - traditional)" value="TraditionalChinese"/>
+      <choice name="한국어 (Korean)" value="Korean"/>
+      <choice name="Taiwanese" value="Taiwanese"/>
+      <choice name="English (UK)" value="BritishEnglish"/>
+      <choice name="Français (Canada)" value="CanadianFrench"/>
+      <choice name="Español (Spanish - South America)" value="LatinAmericanSpanish"/>
+      <choice name="Русский" value="Russian"/>
     </feature>
     <feature submenu="EMULATION" name="MEMORY MANAGER MODE" group="ADVANCED SETTINGS" value="memory_manager_mode" description="Greatly affects CPU performance.">
       <choice name="SOFTWARE" value="SoftwarePageTable"/>

--- a/emulatorLauncher/Generators/Citra.Generator.cs
+++ b/emulatorLauncher/Generators/Citra.Generator.cs
@@ -77,6 +77,26 @@ namespace emulatorLauncher
                     ini.WriteValue("UI", "enable_discord_presence", "false");
                 }
 
+                ini.WriteValue("Data%20Storage", "use_custom_storage\\default", "false");
+                ini.WriteValue("Data%20Storage", "use_custom_storage", "true");
+
+                string citraNandPath = Path.Combine(AppConfig.GetFullPath("saves"), "3ds", "Citra", "nand");
+                if (!Directory.Exists(citraNandPath)) try { Directory.CreateDirectory(citraNandPath); }
+                    catch { }
+                ini.WriteValue("Data%20Storage", "nand_directory\\default", "false");
+                ini.WriteValue("Data%20Storage", "nand_directory", citraNandPath.Replace("\\", "/"));
+
+                // Write nand settings (language)
+                string nandPath = Path.Combine(citraNandPath, "data", "00000000000000000000000000000000", "sysdata", "00010017", "00000000", "config");
+                if (File.Exists(nandPath))
+                    Write3DSnand(nandPath);
+
+                string sdmcPath = Path.Combine(AppConfig.GetFullPath("saves"), "3ds", "Citra", "sdmc");
+                if (!Directory.Exists(sdmcPath)) try { Directory.CreateDirectory(sdmcPath); }
+                    catch { }
+                ini.WriteValue("Data%20Storage", "sdmc_directory\\default", "false");
+                ini.WriteValue("Data%20Storage", "sdmc_directory", sdmcPath.Replace("\\", "/"));
+
                 ini.WriteValue("UI", "Updater\\check_for_update_on_start\\default", "false");
                 ini.WriteValue("UI", "Updater\\check_for_update_on_start", "false");
 
@@ -185,11 +205,6 @@ namespace emulatorLauncher
                     ini.WriteValue("Utility", "preload_textures", "false");
                 }
             }
-
-            // Write nand settings (language)
-            string nandPath = Path.Combine(path, "user", "nand", "data", "00000000000000000000000000000000", "sysdata", "00010017", "00000000", "config");
-            if (File.Exists(nandPath))
-                Write3DSnand(nandPath);
         }
 
         private void Write3DSnand(string path)

--- a/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
+++ b/emulatorLauncher/Generators/LibRetro.CoreOptions.cs
@@ -1035,6 +1035,7 @@ namespace emulatorLauncher.libRetro
 
             BindFeature(coreSettings, "citra_analog_function", "citra_analog_function", "C-Stick and Touchscreen Pointer");
             BindFeature(coreSettings, "citra_mouse_touchscreen", "citra_mouse_touchscreen", "enabled");
+            BindFeature(coreSettings, "citra_render_touchscreen", "citra_render_touchscreen", "disabled");
         }
 
         private void ConfigureMednafenSaturn(ConfigFile retroarchConfig, ConfigFile coreSettings, string system, string core)

--- a/emulatorLauncher/Generators/Mame64.Bezels.cs
+++ b/emulatorLauncher/Generators/Mame64.Bezels.cs
@@ -87,9 +87,9 @@ namespace emulatorLauncher
             }
 
             // Check if ratio is forced
-            if (Features.IsSupported("ratio") && SystemConfig.isOptSet("ratio"))
+            if (Features.IsSupported("mame_ratio") && SystemConfig.isOptSet("mame_ratio"))
             {
-                var ratio = Program.SystemConfig["ratio"].ToRatio();
+                var ratio = Program.SystemConfig["mame_ratio"].ToRatio();
                 if (ratio != 0)
                 {
                     int height = infos.height.GetValueOrDefault() - infos.top.GetValueOrDefault() - infos.bottom.GetValueOrDefault();

--- a/emulatorLauncher/Generators/Ppsspp.Generator.cs
+++ b/emulatorLauncher/Generators/Ppsspp.Generator.cs
@@ -30,7 +30,7 @@ namespace emulatorLauncher
             return new ProcessStartInfo()
             {
                 FileName = exe,
-                Arguments = "-escapeexitsemu -fullscreen \"" + rom + "\"",
+                Arguments = "--escape-exit -fullscreen \"" + rom + "\"",
                 WorkingDirectory = path,
             };
         }
@@ -43,38 +43,101 @@ namespace emulatorLauncher
             {
                 using (var ini = new IniFile(iniFile, IniOptions.UseSpaces))
                 {
+                    // Graphics
                     ini.WriteValue("Graphics", "FullScreen", "True");
+
+                    if (SystemConfig.isOptSet("ppsspp_resolution") && !string.IsNullOrEmpty(SystemConfig["ppsspp_resolution"]))
+                        ini.WriteValue("Graphics", "InternalResolution", SystemConfig["ppsspp_resolution"]);
+                    else
+                        ini.WriteValue("Graphics", "InternalResolution", "0");
+
+                    if (SystemConfig.isOptSet("ppsspp_backend") && !string.IsNullOrEmpty(SystemConfig["ppsspp_backend"]))
+                        ini.WriteValue("Graphics", "GraphicsBackend", SystemConfig["ppsspp_backend"]);
+                    else
+                        ini.WriteValue("Graphics", "GraphicsBackend", "0 (OPENGL)");
+
+                    if (SystemConfig.isOptSet("ppsspp_msaa") && !string.IsNullOrEmpty(SystemConfig["ppsspp_msaa"]))
+                        ini.WriteValue("Graphics", "MultiSampleLevel", SystemConfig["ppsspp_msaa"]);
+                    else
+                        ini.WriteValue("Graphics", "MultiSampleLevel", "0");
+
+                    if (SystemConfig.isOptSet("ppsspp_vsync") && !SystemConfig.getOptBoolean("ppsspp_vsync"))
+                        ini.WriteValue("Graphics", "VSyncInterval", "False");
+                    else
+                        ini.WriteValue("Graphics", "VSyncInterval", "True");
+
+                    if (SystemConfig.isOptSet("ppsspp_frame_skipping") && !string.IsNullOrEmpty(SystemConfig["ppsspp_frame_skipping"]))
+                        ini.WriteValue("Graphics", "FrameSkip", SystemConfig["ppsspp_frame_skipping"]);
+                    else
+                        ini.WriteValue("Graphics", "FrameSkip", "0");
+
+                    if (SystemConfig.isOptSet("ppsspp_frameskip_type") && !string.IsNullOrEmpty(SystemConfig["ppsspp_frameskip_type"]))
+                        ini.WriteValue("Graphics", "FrameSkipType", SystemConfig["ppsspp_frameskip_type"]);
+                    else
+                        ini.WriteValue("Graphics", "FrameSkipType", "0");
+
+                    if (SystemConfig.isOptSet("ppsspp_textureenhancement") && !string.IsNullOrEmpty(SystemConfig["ppsspp_textureenhancement"]) && SystemConfig["ppsspp_textureenhancement"].Contains("Tex"))
+                    {
+                        ini.WriteValue("Graphics", "TexHardwareScaling", "True");
+                        ini.WriteValue("Graphics", "TextureShader", SystemConfig["ppsspp_textureenhancement"]);
+                        ini.WriteValue("Graphics", "TexScalingLevel", "1");
+                        ini.WriteValue("Graphics", "TexScalingType", "0");
+                    }
+                    else if (SystemConfig.isOptSet("ppsspp_textureenhancement") && !string.IsNullOrEmpty(SystemConfig["ppsspp_textureenhancement"]))
+                    {
+                        ini.WriteValue("Graphics", "TexScalingType", SystemConfig["ppsspp_textureenhancement"]);
+                        ini.WriteValue("Graphics", "TexHardwareScaling", "False");
+                        ini.WriteValue("Graphics", "TextureShader", "Off");
+                        
+                        if (SystemConfig.isOptSet("ppsspp_textureenhancement_level") && !string.IsNullOrEmpty(SystemConfig["ppsspp_textureenhancement_level"]) && SystemConfig["ppsspp_textureenhancement_level"] != "1")
+                        {
+                            ini.WriteValue("Graphics", "TexScalingLevel", SystemConfig["ppsspp_textureenhancement_level"]);
+                            ini.WriteValue("Graphics", "TexDeposterize", "True");
+                        }
+                    }
+                    else
+                    {
+                        ini.WriteValue("Graphics", "TexHardwareScaling", "False");
+                        ini.WriteValue("Graphics", "TextureShader", "Off");
+                        ini.WriteValue("Graphics", "TexScalingLevel", "1");
+                        ini.WriteValue("Graphics", "TexScalingType", "0");
+                        ini.WriteValue("Graphics", "TexDeposterize", "False");
+                    }
+
+                    if (SystemConfig.isOptSet("ppsspp_anisotropicfilter") && !string.IsNullOrEmpty(SystemConfig["ppsspp_anisotropicfilter"]))
+                        ini.WriteValue("Graphics", "AnisotropyLevel", SystemConfig["ppsspp_anisotropicfilter"]);
+                    else
+                        ini.WriteValue("Graphics", "AnisotropyLevel", "0");
+
+                    if (SystemConfig.isOptSet("ppsspp_texture_filtering") && !string.IsNullOrEmpty(SystemConfig["ppsspp_texture_filtering"]))
+                        ini.WriteValue("Graphics", "TextureFiltering", SystemConfig["ppsspp_texture_filtering"]);
+                    else
+                        ini.WriteValue("Graphics", "TextureFiltering", "1");
+
+                    // Controls
+                    if (SystemConfig.isOptSet("ppsspp_mouse") && SystemConfig.getOptBoolean("ppsspp_mouse"))
+                        ini.WriteValue("Control", "UseMouse", "True");
+                    else
+                        ini.WriteValue("Control", "UseMouse", "False");
+
+                    // Audio
+                    if (SystemConfig.isOptSet("ppsspp_audiobackend") && !string.IsNullOrEmpty(SystemConfig["ppsspp_audiobackend"]))
+                        ini.WriteValue("Sound", "AudioBackend", SystemConfig["ppsspp_audiobackend"]);
+                    else
+                        ini.WriteValue("Sound", "AudioBackend", "0");
+
+                    // System Param
+                    if (SystemConfig.isOptSet("ppsspp_confirmbutton") && SystemConfig.getOptBoolean("ppsspp_confirmbutton"))
+                        ini.WriteValue("SystemParam", "ButtonPreference", "0");
+                    else
+                        ini.WriteValue("SystemParam", "ButtonPreference", "1");
+
                     // Discord
                     if (SystemConfig.isOptSet("discord") && SystemConfig.getOptBoolean("discord"))
                         ini.WriteValue("General", "DiscordPresence", "True");
                     else
                         ini.WriteValue("General", "DiscordPresence", "False");
 
-                    //if (SystemConfig.isOptSet("showFPS") && SystemConfig.getOptBoolean("showFPS"))
-                    if (SystemConfig.isOptSet("DrawFramerate") && SystemConfig.getOptBoolean("DrawFramerate"))
-                        ini.WriteValue("Graphics", "ShowFPSCounter", "3");
-                    else
-                        ini.WriteValue("Graphics", "ShowFPSCounter", "0");
-
-                    if (SystemConfig.isOptSet("frameskip") && SystemConfig.getOptBoolean("frameskip"))
-                        ini.WriteValue("Graphics", "FrameSkip", SystemConfig["frameskip"]);
-                    else
-                        ini.WriteValue("Graphics", "FrameSkip", "0");
-
-                    if (SystemConfig.isOptSet("frameskiptype") && !string.IsNullOrEmpty(SystemConfig["frameskiptype"]))
-                        ini.WriteValue("Graphics", "FrameSkipType", SystemConfig["frameskiptype"]);
-                    else
-                        ini.WriteValue("Graphics", "FrameSkipType", "0");
-
-                    if (SystemConfig.isOptSet("internalresolution") && !string.IsNullOrEmpty(SystemConfig["internalresolution"]))
-                        ini.WriteValue("Graphics", "InternalResolution", SystemConfig["internalresolution"]);
-                    else
-                        ini.WriteValue("Graphics", "InternalResolution", "0");
-
-                    if (SystemConfig.isOptSet("rewind") && SystemConfig.getOptBoolean("rewind"))
-                        ini.WriteValue("General", "RewindFlipFrequency", "300");
-                    else
-                        ini.WriteValue("General", "RewindFlipFrequency", "0");
                 }
             }
 

--- a/emulatorLauncher/Generators/Ppsspp.Generator.cs
+++ b/emulatorLauncher/Generators/Ppsspp.Generator.cs
@@ -161,9 +161,14 @@ namespace emulatorLauncher
                         ini.WriteValue("General", "DiscordPresence", "True");
                     else
                         ini.WriteValue("General", "DiscordPresence", "False");
+
+                    // Shader Set
+                    if (SystemConfig.isOptSet("ppsspp_shader") && !string.IsNullOrEmpty(SystemConfig["ppsspp_shader"]))
+                        ini.WriteValue("PostShaderList", "PostShader1", SystemConfig["ppsspp_shader"]);
+                    else if (Features.IsSupported("ppsspp_shader"))
+                        ini.ClearSection("PostShaderList");
                 }
             }
-
             catch { }
         }
     }

--- a/emulatorLauncher/Generators/Ppsspp.Generator.cs
+++ b/emulatorLauncher/Generators/Ppsspp.Generator.cs
@@ -51,6 +51,22 @@ namespace emulatorLauncher
                     else
                         ini.WriteValue("Graphics", "InternalResolution", "0");
 
+                    if (SystemConfig.isOptSet("ppsspp_ratio") && !string.IsNullOrEmpty(SystemConfig["ppsspp_ratio"]) && SystemConfig["ppsspp_ratio"] == "stretch")
+                    {
+                        ini.WriteValue("Graphics", "DisplayStretch", "True");
+                        ini.WriteValue("Graphics", "DisplayAspectRatio", "1.000000");
+                    }
+                    else if (SystemConfig.isOptSet("ppsspp_ratio") && !string.IsNullOrEmpty(SystemConfig["ppsspp_ratio"]))
+                    {
+                        ini.WriteValue("Graphics", "DisplayStretch", "False");
+                        ini.WriteValue("Graphics", "DisplayAspectRatio", SystemConfig["ppsspp_ratio"]);
+                    }
+                    else
+                    {
+                        ini.WriteValue("Graphics", "DisplayStretch", "False");
+                        ini.WriteValue("Graphics", "DisplayAspectRatio", "1.000000");
+                    }
+
                     if (SystemConfig.isOptSet("ppsspp_backend") && !string.IsNullOrEmpty(SystemConfig["ppsspp_backend"]))
                         ini.WriteValue("Graphics", "GraphicsBackend", SystemConfig["ppsspp_backend"]);
                     else
@@ -114,6 +130,14 @@ namespace emulatorLauncher
                     else
                         ini.WriteValue("Graphics", "TextureFiltering", "1");
 
+                    if (SystemConfig.isOptSet("Integer_Scaling") && SystemConfig.getOptBoolean("Integer_Scaling"))
+                    { 
+                        ini.WriteValue("Graphics", "DisplayIntegerScale", "True");
+                        ini.WriteValue("Graphics", "DisplayAspectRatio", "1.000000");
+                    }
+                    else
+                        ini.WriteValue("Graphics", "DisplayIntegerScale", "False");
+
                     // Controls
                     if (SystemConfig.isOptSet("ppsspp_mouse") && SystemConfig.getOptBoolean("ppsspp_mouse"))
                         ini.WriteValue("Control", "UseMouse", "True");
@@ -137,7 +161,6 @@ namespace emulatorLauncher
                         ini.WriteValue("General", "DiscordPresence", "True");
                     else
                         ini.WriteValue("General", "DiscordPresence", "False");
-
                 }
             }
 

--- a/emulatorLauncher/Generators/Rpcs3.Generator.cs
+++ b/emulatorLauncher/Generators/Rpcs3.Generator.cs
@@ -245,6 +245,7 @@ namespace emulatorLauncher
             // Handle System part of yml file
             var system_region = yml.GetOrCreateContainer("System");
             BindFeature(system_region, "License Area", "ps3_region", "SCEE");
+            BindFeature(system_region, "Language", "ps3_language", GetDefaultPS3Language());
 
             // Handle Miscellaneous part of yml file
             var misc = yml.GetOrCreateContainer("Miscellaneous");
@@ -255,6 +256,39 @@ namespace emulatorLauncher
 
             // Save to yml file
             yml.Save();
+        }
+
+        private string GetDefaultPS3Language()
+        {
+            Dictionary<string, string> availableLanguages = new Dictionary<string, string>()
+            {
+                { "zh", "Chinese (Simplified)" },
+                { "nl", "Dutch" },
+                { "en", "English (US)" },
+                { "fr", "French" },
+                { "de", "German" },
+                { "it", "Italian" },
+                { "ko", "Korean" },
+                { "jp", "Japanese" },
+                { "pl", "Polish" },
+                { "es", "Spanish" },
+                { "pt", "Portuguese (Portugal)" },
+                { "ru", "Russian" },
+                { "tw", "Chinese (Simplified)" }
+            };
+
+            // Special case for Taiwanese which is zh_TW
+            if (SystemConfig["Language"] == "zh_TW")
+                return "Chinese (Simplified)";
+
+            string lang = GetCurrentLanguage();
+            if (!string.IsNullOrEmpty(lang))
+            {
+                string ret;
+                if (availableLanguages.TryGetValue(lang, out ret))
+                    return ret;
+            }
+            return "English (US)";
         }
     }
 }

--- a/emulatorLauncher/Generators/Ryujinx.Generator.cs
+++ b/emulatorLauncher/Generators/Ryujinx.Generator.cs
@@ -85,7 +85,7 @@ namespace emulatorLauncher
                 json["enable_discord_integration"] = "false";
 
             //System
-            json["system_language"] = GetDefaultswitchLanguage();
+            BindFeature(json, "system_language", "switch_language", GetDefaultswitchLanguage());
             BindFeature(json, "enable_vsync", "vsync", "true");
             BindFeature(json, "enable_ptc", "enable_ptc", "true");
             BindFeature(json, "enable_fs_integrity_checks", "enable_fs_integrity_checks", "true");

--- a/emulatorLauncher/Generators/Yuzu.Generator.cs
+++ b/emulatorLauncher/Generators/Yuzu.Generator.cs
@@ -258,6 +258,13 @@ namespace emulatorLauncher
                 else if (Features.IsSupported("resolution_setup"))
                     ini.WriteValue("Renderer", "resolution_setup", "2");
 
+                // Aspect ratio
+                ini.WriteValue("Renderer", "aspect_ratio\\default", "false");
+                if (SystemConfig.isOptSet("yuzu_ratio") && !string.IsNullOrEmpty(SystemConfig["yuzu_ratio"]))
+                    ini.WriteValue("Renderer", "aspect_ratio", SystemConfig["yuzu_ratio"]);
+                else if (Features.IsSupported("yuzu_ratio"))
+                    ini.WriteValue("Renderer", "aspect_ratio", "0");
+
                 // Anisotropic filtering
                 ini.WriteValue("Renderer", "max_anisotropy\\default", "false");
                 if (SystemConfig.isOptSet("yuzu_anisotropy") && !string.IsNullOrEmpty(SystemConfig["yuzu_anisotropy"]))

--- a/emulatorLauncher/Generators/Yuzu.Generator.cs
+++ b/emulatorLauncher/Generators/Yuzu.Generator.cs
@@ -98,7 +98,7 @@ namespace emulatorLauncher
 
             using (var ini = new IniFile(conf))
             {
-                // Set up paths
+                /* Set up paths
                 string switchSavesPath = Path.Combine(AppConfig.GetFullPath("saves"), "switch");
                 if (!Directory.Exists(switchSavesPath)) try { Directory.CreateDirectory(switchSavesPath); }
                     catch { }
@@ -141,7 +141,7 @@ namespace emulatorLauncher
                 {
                     ini.WriteValue("Data%20Storage", "load_directory\\default", "false");
                     ini.WriteValue("Data%20Storage", "load_directory", loadPath.Replace("\\", "/"));
-                }
+                }*/
 
                 //language
                 ini.WriteValue("System", "language_index\\default", "false");

--- a/emulatorLauncher/emulatorLauncher.csproj
+++ b/emulatorLauncher/emulatorLauncher.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\..\EmulationStation\</OutputPath>
+    <OutputPath>..\..\..\..\..\..\RetroBat5.2\emulationstation\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>

--- a/emulatorLauncher/emulatorLauncher.csproj
+++ b/emulatorLauncher/emulatorLauncher.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\..\..\..\..\..\RetroBat5.2\emulationstation\</OutputPath>
+    <OutputPath>..\..\EmulationStation\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>


### PR DESCRIPTION
yuzu - add ratio
global: changed some features to "preset=switch"