### PR TITLE
use programFilesX86 path as fallback

### DIFF
--- a/emulatorLauncher/Generators/AmigaForever.Generator.cs
+++ b/emulatorLauncher/Generators/AmigaForever.Generator.cs
@@ -15,6 +15,11 @@ namespace emulatorLauncher
 
             string exe = Path.Combine(path, "AmigaForever.exe");
             if (!File.Exists(exe))
+            {
+                path = Path.Combine(Environment.ExpandEnvironmentVariables("%ProgramFiles(x86)%"), "Cloanto", "Amiga Forever");
+                exe = Path.Combine(path, "AmigaForever.exe");
+            }
+            if (!File.Exists(exe))
                 return null;
 
             return new ProcessStartInfo()


### PR DESCRIPTION
if amiga forever executable is not found in the default emulators folder, the launcher will look for it in programFilesX86 and use that path as fallback